### PR TITLE
Change linting rules for compatibility with Black

### DIFF
--- a/tests/test_pep8.py
+++ b/tests/test_pep8.py
@@ -166,7 +166,7 @@ class TestCodeFormat(unittest.TestCase):
             paths=self.files,
             reporter=CustomReport,
         )
-        black_ignores = ("E203", "E231", "E251", "E501", "W503")
+        black_ignores = ("E203", "E231", "E251", "W503")
         checker.options.ignore = checker.options.ignore + black_ignores
         checker.options.max_line_length = 128
         report = checker.check_files()


### PR DESCRIPTION
[Black](https://github.com/psf/black) is a widely used code-formatter, which enforces strict style rules to python code.
In this pull-request, I propose to add a few pep8 linting rules to the ignore list in order to be compatible with the automatic code-formatting of Black.
