### PR TITLE
Compliance of pose estimation with saving/loading specs

### DIFF
--- a/docs/reference/lightweight-open-pose.md
+++ b/docs/reference/lightweight-open-pose.md
@@ -261,7 +261,7 @@ Parameters:
 
   pose_estimator = LightweightOpenPoseLearner(device="cuda", temp_path='./parent_dir')
   pose_estimator.download()  # Download the default pretrained mobilenet model in the temp_path
-  pose_estimator.load("./parent_dir/trainedModel")
+  pose_estimator.load("./parent_dir/mobilenet_openpose")
   pose_estimator.download(mode="test_data")  # Download a test data taken from COCO2017
 
   img = cv2.imread('./parent_dir/dataset/image/000000000785.jpg')
@@ -283,7 +283,7 @@ Parameters:
   pose_estimator = LightweightOpenPoseLearner(temp_path='./parent_dir')
   
   pose_estimator.download()  # Download the default pretrained mobilenet model in the temp_path
-  pose_estimator.load("./parent_dir/trainedModel")
+  pose_estimator.load("./parent_dir/mobilenet_openpose")
   pose_estimator.optimize(do_constant_folding=True)
   pose_estimator.save('./parent_dir/optimized_model')
   ```

--- a/src/perception/pose_estimation/lightweight_open_pose/lightweight_open_pose_learner.py
+++ b/src/perception/pose_estimation/lightweight_open_pose/lightweight_open_pose_learner.py
@@ -915,7 +915,7 @@ class LightweightOpenPoseLearner(Learner):
 
         if mode == "pretrained":
             # Create model's folder
-            path = os.path.join(path, "trainedModel")
+            path = os.path.join(path, "mobilenet_openpose")
             if not os.path.exists(path):
                 os.makedirs(path)
 
@@ -924,17 +924,17 @@ class LightweightOpenPoseLearner(Learner):
 
             # Download the model's files
             if self.backbone == "mobilenet":
-                if not os.path.exists(os.path.join(path, "trainedModel.json")):
-                    file_url = os.path.join(url, "trainedModel/trainedModel.json")
-                    urlretrieve(file_url, os.path.join(path, "trainedModel.json"))
+                if not os.path.exists(os.path.join(path, "mobilenet_openpose.json")):
+                    file_url = os.path.join(url, "mobilenet_openpose/mobilenet_openpose.json")
+                    urlretrieve(file_url, os.path.join(path, "mobilenet_openpose.json"))
                     if verbose:
                         print("Downloaded metadata json.")
                 else:
                     if verbose:
                         print("Metadata json file already exists.")
-                if not os.path.exists(os.path.join(path, "trainedModel.pth")):
-                    file_url = os.path.join(url, "trainedModel/trainedModel.pth")
-                    urlretrieve(file_url, os.path.join(path, "trainedModel.pth"))
+                if not os.path.exists(os.path.join(path, "mobilenet_openpose.pth")):
+                    file_url = os.path.join(url, "mobilenet_openpose/mobilenet_openpose.pth")
+                    urlretrieve(file_url, os.path.join(path, "mobilenet_openpose.pth"))
                 else:
                     if verbose:
                         print("Trained model .pth file already exists.")

--- a/tests/sources/tools/perception/pose_estimation/lightweight_open_pose/test_lightweight_open_pose.py
+++ b/tests/sources/tools/perception/pose_estimation/lightweight_open_pose/test_lightweight_open_pose.py
@@ -50,7 +50,7 @@ class TestLightweightOpenPoseLearner(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         # Clean up downloaded files
-        rmdir(os.path.join(cls.temp_dir, "trainedModel"))
+        rmdir(os.path.join(cls.temp_dir, "mobilenet_openpose"))
         rmdir(os.path.join(cls.temp_dir, "dataset"))
         rmfile(os.path.join(cls.temp_dir, "mobilenet_sgd_68.848.pth.tar"))  # Fit downloads weights file
         rmdir(os.path.join(cls.temp_dir))
@@ -67,7 +67,7 @@ class TestLightweightOpenPoseLearner(unittest.TestCase):
 
     def test_eval(self):
         eval_dataset = ExternalDataset(path=os.path.join(self.temp_dir, "dataset"), dataset_type="COCO")
-        self.pose_estimator.load(os.path.join(self.temp_dir, "trainedModel"))
+        self.pose_estimator.load(os.path.join(self.temp_dir, "mobilenet_openpose"))
         results_dict = self.pose_estimator.eval(eval_dataset, use_subset=False, verbose=True, silent=True,
                                                 images_folder_name="image", annotations_filename="annotation.json")
         self.assertNotEqual(len(results_dict['average_precision']), 0,
@@ -79,7 +79,7 @@ class TestLightweightOpenPoseLearner(unittest.TestCase):
 
     def test_infer(self):
         self.pose_estimator.model = None
-        self.pose_estimator.load(os.path.join(self.temp_dir, "trainedModel"))
+        self.pose_estimator.load(os.path.join(self.temp_dir, "mobilenet_openpose"))
 
         img = cv2.imread(os.path.join(self.temp_dir, "dataset", "image", "000000000785.jpg"))
         # Default pretrained mobilenet model detects 18 keypoints on img with id 785
@@ -113,7 +113,7 @@ class TestLightweightOpenPoseLearner(unittest.TestCase):
     def test_optimize(self):
         self.pose_estimator.model = None
         self.pose_estimator.ort_session = None
-        self.pose_estimator.load(os.path.join(self.temp_dir, "trainedModel"))
+        self.pose_estimator.load(os.path.join(self.temp_dir, "mobilenet_openpose"))
         self.pose_estimator.optimize()
         self.assertIsNotNone(self.pose_estimator.ort_session)
         # Cleanup


### PR DESCRIPTION
This is a bugfix for pose estimation in order to ensure compliance with the specs. More specifically, each model should be downloaded in a folder with the same name in order be loaded. Previous tests were passed by hardcoding the model name into the path string. In this bugfix download() function downloads the files in a format that can be directly loaded without any additional effort from the user.