### PR TITLE
Reduce tests frequency

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -2,7 +2,7 @@ name: Test Sources
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 defaults:
   run:


### PR DESCRIPTION
Run tests only on request when the "test" label is set in the PR to save GitHub Action minutes that are limited on private repositories.
It is recommended to run tests locally during the development and set "test" label when it is ready.

Once the repository will turn public this can be reverted back (at least the source code style tests).