### PR TITLE
Split source and code tests labels

### DIFF
--- a/.github/workflows/tests_sources.yml
+++ b/.github/workflows/tests_sources.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   cleanup-runs:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') }}
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
@@ -18,7 +18,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   test-sources:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') }}
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15]
@@ -46,7 +46,7 @@ jobs:
         pip install -r tests/requirements.txt
         python -m unittest discover -s tests
     - name: Test API
-      if: matrix.os == 'ubuntu-20.04'
+      if: ${{ matrix.os == 'ubuntu-20.04' && contains(github.event.pull_request.labels.*.name, 'test tools') }}
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
         export OPENDR_HOME=$PWD


### PR DESCRIPTION
Use different labels for testing sources and methods functionality to speed up the tests run on every commit.