### PR TITLE
upgrade scikit-learn to 0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# OpenDR Toolkit Change Log
+
+## Version 1.X
+Released on XX, XXth, 2022.
+
+  - New Features:
+    - None.
+  - Enhancements:
+    - None.
+  - Bug Fixes:
+    - None.
+  - Dependency Updates:
+    - `heart anomaly detection`: upgraded scikit-learn runtime dependency from 0.21.3 to 0.22 ([#198](https://github.com/opendr-eu/opendr/pull/198)).
+
+## Version 1.0
+Released on December 31th, 2021.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ ______________________________________________________________________
   <a href="#using-opendr-toolkit">Using OpenDR toolkit</a> •
   <a href="projects">Examples</a> •
   <a href="#roadmap">Roadmap</a> •
+  <a href="CHANGELOG.md">Changelog</a> •
   <a href="LICENSE">License</a>
 </p>
 

--- a/src/opendr/perception/heart_anomaly_detection/dependencies.ini
+++ b/src/opendr/perception/heart_anomaly_detection/dependencies.ini
@@ -5,4 +5,4 @@ python=torch==1.7.1
        torchvision==0.8.2
        tensorboard==2.4.1
        tqdm==4.54.0
-       scikit-learn==0.21.3
+       scikit-learn==0.22


### PR DESCRIPTION
0.21.3 causes warnings with the current numpy version. Upgrading it fixes it.