### PR TITLE
Fix copyright dates and double-check rights owner (action required)

### DIFF
--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   cleanup-runs:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
@@ -20,7 +20,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   test-sources:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || github.event_name == 'schedule' }}
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15]
@@ -52,7 +52,7 @@ jobs:
         python -m unittest discover -s tests
   test-tools:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') || github.event_name == 'schedule' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -73,7 +73,7 @@ jobs:
           - control/mobile_manipulation
           - perception/object_detection_2d
           - simulation/human_model_generation
-          - perception/facial_expression_recognition/landmark_based_facial_expression_recognition
+          - perception/facial_expression_recognition
           - control/single_demo_grasp
           # - perception/object_tracking_3d
         include:
@@ -90,7 +90,6 @@ jobs:
       with:
         python-version: 3.8
     - name: Test Tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
         export OPENDR_HOME=$PWD

--- a/.github/workflows/tests_suite_develop.yml
+++ b/.github/workflows/tests_suite_develop.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   cleanup-runs:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || contains(github.event.pull_request.labels.*.name, 'test tools') || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
@@ -18,7 +18,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   test-sources:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || github.event_name == 'schedule' }}
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-10.15]
@@ -51,7 +51,7 @@ jobs:
         python -m unittest discover -s tests
   test-tools:
     needs: cleanup-runs
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') || github.event_name == 'schedule' }}
     strategy:
       matrix:
         os: [ubuntu-20.04]
@@ -72,7 +72,7 @@ jobs:
           - control/mobile_manipulation
           - perception/object_detection_2d
           - simulation/human_model_generation
-          - perception/facial_expression_recognition/landmark_based_facial_expression_recognition
+          - perception/facial_expression_recognition
           - control/single_demo_grasp
           # - perception/object_tracking_3d
         include:
@@ -90,7 +90,6 @@ jobs:
       with:
         python-version: 3.8
     - name: Test Tools
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
         export OPENDR_HOME=$PWD

--- a/dependencies/parse_dependencies.py
+++ b/dependencies/parse_dependencies.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/include/data.h
+++ b/include/data.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/face_recognition.h
+++ b/include/face_recognition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/opendr_utils.h
+++ b/include/opendr_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/target.h
+++ b/include/target.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/c_api/Makefile
+++ b/projects/c_api/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2021 OpenDR project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/c_api/samples/face_recognition/face_recognition_demo.c
+++ b/projects/c_api/samples/face_recognition/face_recognition_demo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/control/eagerx/Makefile
+++ b/projects/control/eagerx/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/mobile_manipulation/mobile_manipulation_demo.py
+++ b/projects/control/mobile_manipulation/mobile_manipulation_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/inference/inference_utils.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/inference/inference_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/inference/single_demo_grasp_camera_stream.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/inference/single_demo_grasp_camera_stream.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/inference/single_demo_inference.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/inference/single_demo_inference.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/camera_publisher.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/camera_publisher.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2020 Cyberbotics Ltd.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/constants.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/gripper_command.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/gripper_command.py
@@ -1,3 +1,4 @@
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/joint_state_publisher.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/joint_state_publisher.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2020 Cyberbotics Ltd.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/panda_ros.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/panda_ros.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 1996-2020 Cyberbotics Ltd.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/single_demo_grasp_action.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/single_demo_grasp_action.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/trajectory_follower.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/trajectory_follower.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2020 Cyberbotics Ltd.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/utilities.py
+++ b/projects/control/single_demo_grasp/simulation_ws/src/single_demo_grasping_demo/scripts/utilities.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/face_detection_retinaface.py
+++ b/projects/opendr_ws/src/perception/scripts/face_detection_retinaface.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/face_recognition.py
+++ b/projects/opendr_ws/src/perception/scripts/face_recognition.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/heart_anomaly_detection.py
+++ b/projects/opendr_ws/src/perception/scripts/heart_anomaly_detection.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/image_dataset.py
+++ b/projects/opendr_ws/src/perception/scripts/image_dataset.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/landmark_based_facial_expression_recognition.py
+++ b/projects/opendr_ws/src/perception/scripts/landmark_based_facial_expression_recognition.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/object_detection_2d_centernet.py
+++ b/projects/opendr_ws/src/perception/scripts/object_detection_2d_centernet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/object_detection_2d_detr.py
+++ b/projects/opendr_ws/src/perception/scripts/object_detection_2d_detr.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/object_detection_2d_gem.py
+++ b/projects/opendr_ws/src/perception/scripts/object_detection_2d_gem.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/object_detection_2d_ssd.py
+++ b/projects/opendr_ws/src/perception/scripts/object_detection_2d_ssd.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/object_detection_2d_yolov3.py
+++ b/projects/opendr_ws/src/perception/scripts/object_detection_2d_yolov3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/object_detection_3d_voxel.py
+++ b/projects/opendr_ws/src/perception/scripts/object_detection_3d_voxel.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/object_tracking_2d_deep_sort.py
+++ b/projects/opendr_ws/src/perception/scripts/object_tracking_2d_deep_sort.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/object_tracking_2d_fair_mot.py
+++ b/projects/opendr_ws/src/perception/scripts/object_tracking_2d_fair_mot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/object_tracking_3d_ab3dmot.py
+++ b/projects/opendr_ws/src/perception/scripts/object_tracking_3d_ab3dmot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
+++ b/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/point_cloud_dataset.py
+++ b/projects/opendr_ws/src/perception/scripts/point_cloud_dataset.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/pose_estimation.py
+++ b/projects/opendr_ws/src/perception/scripts/pose_estimation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/rgbd_hand_gesture_recognition.py
+++ b/projects/opendr_ws/src/perception/scripts/rgbd_hand_gesture_recognition.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/semantic_segmentation_bisenet.py
+++ b/projects/opendr_ws/src/perception/scripts/semantic_segmentation_bisenet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/skeleton_based_action_recognition.py
+++ b/projects/opendr_ws/src/perception/scripts/skeleton_based_action_recognition.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/speech_command_recognition.py
+++ b/projects/opendr_ws/src/perception/scripts/speech_command_recognition.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/perception/scripts/video_activity_recognition.py
+++ b/projects/opendr_ws/src/perception/scripts/video_activity_recognition.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/ros_bridge/setup.py
+++ b/projects/opendr_ws/src/ros_bridge/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/ros_bridge/src/opendr_bridge/bridge.py
+++ b/projects/opendr_ws/src/ros_bridge/src/opendr_bridge/bridge.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/simulation/scripts/human_model_generation_client.py
+++ b/projects/opendr_ws/src/simulation/scripts/human_model_generation_client.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/opendr_ws/src/simulation/scripts/human_model_generation_service.py
+++ b/projects/opendr_ws/src/simulation/scripts/human_model_generation_service.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/activity_recognition/demos/online_recognition/demo.py
+++ b/projects/perception/activity_recognition/demos/online_recognition/demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/activity_recognition/demos/online_recognition/setup.py
+++ b/projects/perception/activity_recognition/demos/online_recognition/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/face_recognition/demos/benchmarking_demo.py
+++ b/projects/perception/face_recognition/demos/benchmarking_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/face_recognition/demos/eval_demo.py
+++ b/projects/perception/face_recognition/demos/eval_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/face_recognition/demos/inference_demo.py
+++ b/projects/perception/face_recognition/demos/inference_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/demo.py
+++ b/projects/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/heart_anomaly_detection/demo.py
+++ b/projects/perception/heart_anomaly_detection/demo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/demos/benchmarking_demo.py
+++ b/projects/perception/lightweight_open_pose/demos/benchmarking_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/demos/eval_demo.py
+++ b/projects/perception/lightweight_open_pose/demos/eval_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/demos/inference_demo.py
+++ b/projects/perception/lightweight_open_pose/demos/inference_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/demos/webcam_demo.py
+++ b/projects/perception/lightweight_open_pose/demos/webcam_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/jetbot/fall_controller.py
+++ b/projects/perception/lightweight_open_pose/jetbot/fall_controller.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/jetbot/utils/active.py
+++ b/projects/perception/lightweight_open_pose/jetbot/utils/active.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/jetbot/utils/pose_controller.py
+++ b/projects/perception/lightweight_open_pose/jetbot/utils/pose_controller.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/jetbot/utils/pose_utils.py
+++ b/projects/perception/lightweight_open_pose/jetbot/utils/pose_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/jetbot/utils/robot_interface.py
+++ b/projects/perception/lightweight_open_pose/jetbot/utils/robot_interface.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/jetbot/utils/visualization.py
+++ b/projects/perception/lightweight_open_pose/jetbot/utils/visualization.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/lightweight_open_pose/jetbot/utils/webots.py
+++ b/projects/perception/lightweight_open_pose/jetbot/utils/webots.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/multimodal_human_centric/gesture_recognition_demo.py
+++ b/projects/perception/multimodal_human_centric/gesture_recognition_demo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/centernet/eval_demo.py
+++ b/projects/perception/object_detection_2d/centernet/eval_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/centernet/inference_demo.py
+++ b/projects/perception/object_detection_2d/centernet/inference_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/centernet/train_demo.py
+++ b/projects/perception/object_detection_2d/centernet/train_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/detr/eval_demo.py
+++ b/projects/perception/object_detection_2d/detr/eval_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/detr/inference_demo.py
+++ b/projects/perception/object_detection_2d/detr/inference_demo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/detr/train_demo.py
+++ b/projects/perception/object_detection_2d/detr/train_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/gem/inference_demo.py
+++ b/projects/perception/object_detection_2d/gem/inference_demo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/retinaface/eval_demo.py
+++ b/projects/perception/object_detection_2d/retinaface/eval_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/retinaface/inference_demo.py
+++ b/projects/perception/object_detection_2d/retinaface/inference_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/retinaface/train_demo.py
+++ b/projects/perception/object_detection_2d/retinaface/train_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/ssd/eval_demo.py
+++ b/projects/perception/object_detection_2d/ssd/eval_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/ssd/inference_demo.py
+++ b/projects/perception/object_detection_2d/ssd/inference_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/ssd/train_demo.py
+++ b/projects/perception/object_detection_2d/ssd/train_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/yolov3/eval_demo.py
+++ b/projects/perception/object_detection_2d/yolov3/eval_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/yolov3/inference_demo.py
+++ b/projects/perception/object_detection_2d/yolov3/inference_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_2d/yolov3/train_demo.py
+++ b/projects/perception/object_detection_2d/yolov3/train_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/data_generators.py
+++ b/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/data_generators.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aarhus University.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/demo.py
+++ b/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/draw_point_clouds.py
+++ b/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/draw_point_clouds.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aarhus University.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/metrics.py
+++ b/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/metrics.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aarhus University.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/channel.py
+++ b/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/channel.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aarhus University.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/main.py
+++ b/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/main.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aarhus University.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/o3m_lidar.py
+++ b/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/o3m_lidar.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aarhus University.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/structures.py
+++ b/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/structures.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aarhus University.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/rplidar_processor.py
+++ b/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/rplidar_processor.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aarhus University.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/setup.py
+++ b/projects/perception/object_detection_3d/demos/voxel_object_detection_3d/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_tracking_2d/demos/fair_mot_deep_sort/data_generators.py
+++ b/projects/perception/object_tracking_2d/demos/fair_mot_deep_sort/data_generators.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_tracking_2d/demos/fair_mot_deep_sort/demo.py
+++ b/projects/perception/object_tracking_2d/demos/fair_mot_deep_sort/demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/object_tracking_2d/demos/fair_mot_deep_sort/setup.py
+++ b/projects/perception/object_tracking_2d/demos/fair_mot_deep_sort/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/panoptic_segmentation/efficient_ps/example_usage.py
+++ b/projects/perception/panoptic_segmentation/efficient_ps/example_usage.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/semantic_segmentation/bisenet/eval_demo.py
+++ b/projects/perception/semantic_segmentation/bisenet/eval_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/semantic_segmentation/bisenet/inference_demo.py
+++ b/projects/perception/semantic_segmentation/bisenet/inference_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/semantic_segmentation/bisenet/train_demo.py
+++ b/projects/perception/semantic_segmentation/bisenet/train_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/skeleton_based_action_recognition/demos/demo.py
+++ b/projects/perception/skeleton_based_action_recognition/demos/demo.py
@@ -1,5 +1,5 @@
 
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/skeleton_based_action_recognition/demos/skeleton_extraction.py
+++ b/projects/perception/skeleton_based_action_recognition/demos/skeleton_extraction.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/launch/experiment.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/launch/experiment.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/launch/experiment_real_data.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/launch/experiment_real_data.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/err_collector
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/err_collector
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/fmp_plot
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/fmp_plot
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/gt_mapping
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/gt_mapping
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/occ_map_saver
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/occ_map_saver
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/odom_pose
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/odom_pose
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/pose_error_calc
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/nodes/pose_error_calc
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/package.xml
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="jose.arce@students.uni-freiburg.de">Jose Arce</maintainer>
 
   <license>
-    Copyright 2020-2021 OpenDR European Project
+    Copyright 2020-2022 OpenDR European Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/scripts/err_curves.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/scripts/err_curves.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/scripts/err_histograms.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/scripts/err_histograms.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/scripts/method_comparison.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/scripts/method_comparison.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/setup.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/enums/disc_states.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/enums/disc_states.py
@@ -1,5 +1,5 @@
 
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/error_data_collector.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/error_data_collector.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/fmp_plotter.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/fmp_plotter.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/ground_truth_mapping.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/ground_truth_mapping.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/map_colorizer.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/map_colorizer.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/net_utils.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/net_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/occ_map_saver.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/occ_map_saver.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/odom_pose_publisher.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/odom_pose_publisher.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/pose_error_calculator.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/pose_error_calculator.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/ros_launcher.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/ros_launcher.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/roscore.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/fmp_slam_eval/src/fmp_slam_eval/roscore.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/package.xml
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="jose.arce@students.uni-freiburg.de">Jose Arce</maintainer>
 
   <license>
-    Copyright 2020-2021 OpenDR European Project
+    Copyright 2020-2022 OpenDR European Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/scripts/mapsim2d.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/scripts/mapsim2d.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/setup.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/setup.py
@@ -1,5 +1,5 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/geometry/primitives/closed_shape_2D.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/geometry/primitives/closed_shape_2D.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/geometry/primitives/line.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/geometry/primitives/line.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/geometry/primitives/polygon.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/geometry/primitives/polygon.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/geometry/primitives/pose.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/geometry/primitives/pose.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/geometry/transform.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/geometry/transform.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/map_obstacles/obstacle.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/map_obstacles/obstacle.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/map_obstacles/polygonal_obstacle.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/map_obstacles/polygonal_obstacle.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/map_simulator_2d.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/map_simulator_2d.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/command.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/command.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/message/bool_msg_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/message/bool_msg_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/message/message_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/message/message_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/misc/comment_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/misc/comment_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/misc/misc_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/misc/misc_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/misc/scan_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/misc/scan_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/misc/sleep_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/misc/sleep_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_circular_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_circular_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_interpol_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_interpol_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_linear_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_linear_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_pose_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_pose_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_rotation_cmd.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/robot_commands/move/move_rotation_cmd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/utils.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/map_simulator/src/map_simulator/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 -include ./global.mk
 
 ifeq ($(CARMENSUPPORT),1)
-SUBDIRS=utils  sensor log configfile scanmatcher carmenwrapper gridfastslam gui gfs-carmen 
+SUBDIRS=utils  sensor log configfile scanmatcher carmenwrapper gridfastslam gui gfs-carmen
 else
 ifeq ($(MACOSX),1)
-SUBDIRS=utils sensor log configfile scanmatcher gridfastslam 
+SUBDIRS=utils sensor log configfile scanmatcher gridfastslam
 else
-SUBDIRS=utils sensor log configfile scanmatcher gridfastslam gui 
+SUBDIRS=utils sensor log configfile scanmatcher gridfastslam gui
 endif
 endif
 

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/configfile/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/configfile/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 OBJS= configfile.o
-APPS= configfile_test 
+APPS= configfile_test
 
 -include ../global.mk
 -include ../build_tools/Makefile.generic-shared-object

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/configfile/configfile.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/configfile/configfile.cpp
@@ -20,7 +20,7 @@
  *
  *****************************************************************/
 
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/configfile/configfile_test.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/configfile/configfile_test.cpp
@@ -20,7 +20,7 @@
  *
  *****************************************************************/
 
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/grid/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/grid/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 OBJS=
 APPS= map_test
 
-LDFLAGS+= 
-CPPFLAGS+= -DNDEBUG 
+LDFLAGS+=
+CPPFLAGS+= -DNDEBUG
 
 -include ../global.mk
 -include ../build_tools/Makefile.app

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/grid/graphmap.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/grid/graphmap.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/grid/map_test.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/grid/map_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gfs2log.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gfs2log.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gfs2neff.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gfs2neff.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gfs2rec.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gfs2rec.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gfsreader.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gfsreader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gridslamprocessor.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gridslamprocessor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gridslamprocessor_tree.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/gridslamprocessor_tree.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/motionmodel.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/gridfastslam/motionmodel.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/configfile/configfile.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/configfile/configfile.h
@@ -21,7 +21,7 @@
  *****************************************************************/
 
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/grid/accessstate.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/grid/accessstate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/grid/array2d.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/grid/array2d.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/grid/harray2d.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/grid/harray2d.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/grid/map.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/grid/map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/gridfastslam/gfsreader.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/gridfastslam/gfsreader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/gridfastslam/gridslamprocessor.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/gridfastslam/gridslamprocessor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/gridfastslam/gridslamprocessor.hxx
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/gridfastslam/gridslamprocessor.hxx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/gridfastslam/motionmodel.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/gridfastslam/motionmodel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/log/carmenconfiguration.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/log/carmenconfiguration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/log/configuration.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/log/configuration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/log/sensorlog.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/log/sensorlog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/log/sensorstream.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/log/sensorstream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/particlefilter/particlefilter.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/particlefilter/particlefilter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/particlefilter/pf.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/particlefilter/pf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/eig3.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/eig3.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/gridlinetraversal.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/gridlinetraversal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/icp.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/icp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/scanmatcher.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/scanmatcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/scanmatcherprocessor.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/scanmatcherprocessor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/smmap.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/scanmatcher/smmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_base/sensor.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_base/sensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_base/sensoreading.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_base/sensoreading.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_base/sensorreading.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_base/sensorreading.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_odometry/odometryreading.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_odometry/odometryreading.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_odometry/odometrysensor.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_odometry/odometrysensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_range/rangereading.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_range/rangereading.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_range/rangesensor.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/sensor/sensor_range/rangesensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/autoptr.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/autoptr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/commandline.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/commandline.h
@@ -21,7 +21,7 @@
  *****************************************************************/
 
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/gvalues.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/gvalues.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/macro_params.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/macro_params.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/movement.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/movement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/point.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/point.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/stat.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/include/gmapping/utils/stat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 OBJS= configuration.o carmenconfiguration.o sensorlog.o sensorstream.o
 APPS= log_test log_plot scanstudio2carmen rdk2carmen
 
-LDFLAGS+=  -lsensor_range -lsensor_odometry -lsensor_base 
-CPPFLAGS+= -I../sensor 
+LDFLAGS+=  -lsensor_range -lsensor_odometry -lsensor_base
+CPPFLAGS+= -I../sensor
 
 -include ../global.mk
 -include ../build_tools/Makefile.generic-shared-object

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/carmenconfiguration.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/carmenconfiguration.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/configuration.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/configuration.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/log_plot.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/log_plot.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/log_test.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/log_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/rdk2carmen.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/rdk2carmen.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/scanstudio2carmen.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/scanstudio2carmen.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/sensorlog.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/sensorlog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/sensorstream.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/log/sensorstream.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/eig3.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/eig3.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/icptest.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/icptest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/line_test.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/line_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/scanmatch_test.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/scanmatch_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/scanmatcher.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/scanmatcher.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/scanmatcher.new.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/scanmatcher.new.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/scanmatcherprocessor.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/scanmatcherprocessor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/smmap.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/scanmatcher/smmap.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_base/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_base/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_base/sensor.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_base/sensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_base/sensorreading.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_base/sensorreading.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_odometry/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_odometry/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_odometry/odometryreading.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_odometry/odometryreading.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_odometry/odometrysensor.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_odometry/odometrysensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_range/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_range/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
 
 -include ../../global.mk
 
-CPPFLAGS+= -I../ 
+CPPFLAGS+= -I../
 LDFLAGS+= -lsensor_base
 
-OBJS= rangesensor.o rangereading.o 
+OBJS= rangesensor.o rangereading.o
 
 -include ../../build_tools/Makefile.generic-shared-object

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_range/rangereading.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_range/rangereading.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_range/rangesensor.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/sensor/sensor_range/rangesensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/utils/Makefile
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/utils/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/utils/autoptr_test.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/utils/autoptr_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/utils/movement.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/utils/movement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/utils/stat.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/utils/stat.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/utils/stat_test.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/openslam_gmapping/utils/stat_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/src/main.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/src/main.cpp
@@ -29,7 +29,7 @@
 
 /* Author: Brian Gerkey */
 
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/src/nodelet.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/src/nodelet.cpp
@@ -27,7 +27,7 @@
  *
  */
 
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/src/replay.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/src/replay.cpp
@@ -2,7 +2,7 @@
  * Copyright 2015 Aldebaran
  */
 
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/src/slam_gmapping.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/src/slam_gmapping.cpp
@@ -30,7 +30,7 @@
 /* Author: Brian Gerkey */
 /* Modified by: Charles DuHadway */
 
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/src/slam_gmapping.h
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/src/slam_gmapping.h
@@ -30,7 +30,7 @@
 /* Author: Brian Gerkey */
 
 /*
- * Copyright 2020-2021 OpenDR European Project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/test/rtest.cpp
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/test/rtest.cpp
@@ -29,7 +29,7 @@
 
 /* Author: Brian Gerkey */
 
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/test/test_map.py
+++ b/projects/perception/slam/full_map_posterior_gmapping/src/slam_gmapping/gmapping/test/test_map.py
@@ -32,7 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/perception/speech_command_recognition/demo.py
+++ b/projects/perception/speech_command_recognition/demo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/src/download_data.py
+++ b/projects/simulation/SMPL+D_human_models/src/download_data.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/src/generate_models.py
+++ b/projects/simulation/SMPL+D_human_models/src/generate_models.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/webots/extract_anims.py
+++ b/projects/simulation/SMPL+D_human_models/webots/extract_anims.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/webots/smpl_webots/controllers/smpl_animation/Makefile
+++ b/projects/simulation/SMPL+D_human_models/webots/smpl_webots/controllers/smpl_animation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,6 @@ ifndef WEBOTS_SKIN_ANIMATION_PATH
 WEBOTS_SKIN_ANIMATION_PATH = ../../libraries
 endif
 INCLUDE = -I"$(WEBOTS_SKIN_ANIMATION_PATH)/smpl_util/include"
-LIBRARIES = -L"$(WEBOTS_SKIN_ANIMATION_PATH)/smpl_util" -lsmpl_util 
+LIBRARIES = -L"$(WEBOTS_SKIN_ANIMATION_PATH)/smpl_util" -lsmpl_util
 # Do not modify the following: this includes Webots global Makefile.include
 include $(WEBOTS_HOME_PATH)/resources/Makefile.include

--- a/projects/simulation/SMPL+D_human_models/webots/smpl_webots/controllers/smpl_animation/smpl_animation.c
+++ b/projects/simulation/SMPL+D_human_models/webots/smpl_webots/controllers/smpl_animation/smpl_animation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/Makefile
+++ b/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/include/quaternion_private.h
+++ b/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/include/quaternion_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/include/smpl_util.h
+++ b/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/include/smpl_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/include/vector3_private.h
+++ b/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/include/vector3_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/src/quaternion.c
+++ b/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/src/quaternion.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/src/smpl_util.c
+++ b/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/src/smpl_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/src/vector3.c
+++ b/projects/simulation/SMPL+D_human_models/webots/smpl_webots/libraries/smpl_util/src/vector3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/projects/simulation/human_dataset_generation/background.py
+++ b/projects/simulation/human_dataset_generation/background.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/simulation/human_dataset_generation/create_background_images.py
+++ b/projects/simulation/human_dataset_generation/create_background_images.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/simulation/human_dataset_generation/create_dataset.py
+++ b/projects/simulation/human_dataset_generation/create_dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/simulation/human_dataset_generation/data_generator.py
+++ b/projects/simulation/human_dataset_generation/data_generator.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/simulation/human_dataset_generation/reformat_cityscapes.py
+++ b/projects/simulation/human_dataset_generation/reformat_cityscapes.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/utils/hyperparameter_tuner/hyperparameter_tuner_demo.py
+++ b/projects/utils/hyperparameter_tuner/hyperparameter_tuner_demo.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/c_api/Makefile
+++ b/src/c_api/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2021 OpenDR project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/c_api/face_recognition.cpp
+++ b/src/c_api/face_recognition.cpp
@@ -1,5 +1,4 @@
-//
-// Copyright 2020-2021 OpenDR project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/c_api/opendr_utils.cpp
+++ b/src/c_api/opendr_utils.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2020-2021 OpenDR project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/_version.py
+++ b/src/opendr/_version.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/Makefile
+++ b/src/opendr/control/mobile_manipulation/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/include/gripper_planner/base_gripper_planner.hpp
+++ b/src/opendr/control/mobile_manipulation/include/gripper_planner/base_gripper_planner.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/include/gripper_planner/gaussian_mixture_model.hpp
+++ b/src/opendr/control/mobile_manipulation/include/gripper_planner/gaussian_mixture_model.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/include/gripper_planner/gmm_planner.hpp
+++ b/src/opendr/control/mobile_manipulation/include/gripper_planner/gmm_planner.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/include/gripper_planner/linear_planner.hpp
+++ b/src/opendr/control/mobile_manipulation/include/gripper_planner/linear_planner.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/robot_env.hpp
+++ b/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/robot_env.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/robot_hsr.hpp
+++ b/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/robot_hsr.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/robot_pr2.hpp
+++ b/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/robot_pr2.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/robot_tiago.hpp
+++ b/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/robot_tiago.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/utils.hpp
+++ b/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/worlds.hpp
+++ b/src/opendr/control/mobile_manipulation/include/mobile_manipulation_rl/worlds.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/envs/__init__.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/envs/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/envs/eeplanner.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/envs/eeplanner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/envs/env_utils.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/envs/env_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/envs/map.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/envs/map.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/envs/mobile_manipulation_env.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/envs/mobile_manipulation_env.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/envs/robotenv.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/envs/robotenv.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/envs/simulator_api.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/envs/simulator_api.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/envs/tasks.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/envs/tasks.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/envs/tasks_chained.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/envs/tasks_chained.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/evaluation.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/evaluation.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/handle_launchfiles.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/handle_launchfiles.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/stablebl_callbacks.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/stablebl_callbacks.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobileRL/utils.py
+++ b/src/opendr/control/mobile_manipulation/mobileRL/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/mobile_manipulation_learner.py
+++ b/src/opendr/control/mobile_manipulation/mobile_manipulation_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/gripper_planner/base_gripper_planner.cpp
+++ b/src/opendr/control/mobile_manipulation/src/gripper_planner/base_gripper_planner.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/gripper_planner/gaussian_mixture_model.cpp
+++ b/src/opendr/control/mobile_manipulation/src/gripper_planner/gaussian_mixture_model.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/gripper_planner/gmm_planner.cpp
+++ b/src/opendr/control/mobile_manipulation/src/gripper_planner/gmm_planner.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/gripper_planner/linear_planner.cpp
+++ b/src/opendr/control/mobile_manipulation/src/gripper_planner/linear_planner.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/pybindings.cpp
+++ b/src/opendr/control/mobile_manipulation/src/pybindings.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/robot_env.cpp
+++ b/src/opendr/control/mobile_manipulation/src/robot_env.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/robot_hsr.cpp
+++ b/src/opendr/control/mobile_manipulation/src/robot_hsr.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/robot_pr2.cpp
+++ b/src/opendr/control/mobile_manipulation/src/robot_pr2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/robot_tiago.cpp
+++ b/src/opendr/control/mobile_manipulation/src/robot_tiago.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/utils.cpp
+++ b/src/opendr/control/mobile_manipulation/src/utils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/mobile_manipulation/src/worlds.cpp
+++ b/src/opendr/control/mobile_manipulation/src/worlds.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 OpenDR European Project
+// Copyright 2020-2022 OpenDR European Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/opendr/control/single_demo_grasp/Makefile
+++ b/src/opendr/control/single_demo_grasp/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/single_demo_grasp/augmentation/augmentation_gui.py
+++ b/src/opendr/control/single_demo_grasp/augmentation/augmentation_gui.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/single_demo_grasp/augmentation/augmentation_utils.py
+++ b/src/opendr/control/single_demo_grasp/augmentation/augmentation_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/single_demo_grasp/training/learner_utils.py
+++ b/src/opendr/control/single_demo_grasp/training/learner_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/control/single_demo_grasp/training/single_demo_grasp_learner.py
+++ b/src/opendr/control/single_demo_grasp/training/single_demo_grasp_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/engine/constants.py
+++ b/src/opendr/engine/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/engine/data.py
+++ b/src/opendr/engine/data.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/engine/datasets.py
+++ b/src/opendr/engine/datasets.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/engine/example_learner.py
+++ b/src/opendr/engine/example_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/engine/learners.py
+++ b/src/opendr/engine/learners.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/engine/target.py
+++ b/src/opendr/engine/target.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/activity_recognition/cox3d/cox3d_learner.py
+++ b/src/opendr/perception/activity_recognition/cox3d/cox3d_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/activity_recognition/datasets/kinetics.py
+++ b/src/opendr/perception/activity_recognition/datasets/kinetics.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/activity_recognition/datasets/utils/transforms.py
+++ b/src/opendr/perception/activity_recognition/datasets/utils/transforms.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/activity_recognition/x3d/x3d_learner.py
+++ b/src/opendr/perception/activity_recognition/x3d/x3d_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/__init__.py
+++ b/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/__init__.py
+++ b/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/cifar_allcnn.py
+++ b/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/cifar_allcnn.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/imagenet_densenet.py
+++ b/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/imagenet_densenet.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/imagenet_resnet.py
+++ b/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/imagenet_resnet.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/imagenet_vgg.py
+++ b/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/imagenet_vgg.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/model_utils.py
+++ b/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/backbones/model_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/data.py
+++ b/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/data.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/learner.py
+++ b/src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/compressive_learning/multilinear_compressive_learning/multilinear_compressive_learner.py
+++ b/src/opendr/perception/compressive_learning/multilinear_compressive_learning/multilinear_compressive_learner.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2020 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/face_recognition/face_recognition_learner.py
+++ b/src/opendr/perception/face_recognition/face_recognition_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/AFEW_data_gen.py
+++ b/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/AFEW_data_gen.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/CASIA_CK_data_gen.py
+++ b/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/CASIA_CK_data_gen.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/data_augmentation.py
+++ b/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/data_augmentation.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/frame_extractor.py
+++ b/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/frame_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/gen_facial_muscles_data.py
+++ b/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/gen_facial_muscles_data.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/landmark_extractor.py
+++ b/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/datasets/landmark_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/models/pstbln.py
+++ b/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/algorithm/models/pstbln.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/progressive_spatio_temporal_bln_learner.py
+++ b/src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/progressive_spatio_temporal_bln_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/heart_anomaly_detection/attention_neural_bag_of_feature/algorithm/__init__.py
+++ b/src/opendr/perception/heart_anomaly_detection/attention_neural_bag_of_feature/algorithm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/heart_anomaly_detection/attention_neural_bag_of_feature/attention_neural_bag_of_feature_learner.py
+++ b/src/opendr/perception/heart_anomaly_detection/attention_neural_bag_of_feature/attention_neural_bag_of_feature_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/heart_anomaly_detection/gated_recurrent_unit/algorithm/__init__.py
+++ b/src/opendr/perception/heart_anomaly_detection/gated_recurrent_unit/algorithm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/heart_anomaly_detection/gated_recurrent_unit/algorithm/data.py
+++ b/src/opendr/perception/heart_anomaly_detection/gated_recurrent_unit/algorithm/data.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/heart_anomaly_detection/gated_recurrent_unit/algorithm/models.py
+++ b/src/opendr/perception/heart_anomaly_detection/gated_recurrent_unit/algorithm/models.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/heart_anomaly_detection/gated_recurrent_unit/algorithm/trainers.py
+++ b/src/opendr/perception/heart_anomaly_detection/gated_recurrent_unit/algorithm/trainers.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/heart_anomaly_detection/gated_recurrent_unit/gated_recurrent_unit_learner.py
+++ b/src/opendr/perception/heart_anomaly_detection/gated_recurrent_unit/gated_recurrent_unit_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/multimodal_human_centric/rgbd_hand_gesture_learner/algorithm/__init__.py
+++ b/src/opendr/perception/multimodal_human_centric/rgbd_hand_gesture_learner/algorithm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/multimodal_human_centric/rgbd_hand_gesture_learner/algorithm/architectures/__init__.py
+++ b/src/opendr/perception/multimodal_human_centric/rgbd_hand_gesture_learner/algorithm/architectures/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/multimodal_human_centric/rgbd_hand_gesture_learner/algorithm/data.py
+++ b/src/opendr/perception/multimodal_human_centric/rgbd_hand_gesture_learner/algorithm/data.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/multimodal_human_centric/rgbd_hand_gesture_learner/rgbd_hand_gesture_learner.py
+++ b/src/opendr/perception/multimodal_human_centric/rgbd_hand_gesture_learner/rgbd_hand_gesture_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/centernet/centernet_learner.py
+++ b/src/opendr/perception/object_detection_2d/centernet/centernet_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/datasets/detection_dataset.py
+++ b/src/opendr/perception/object_detection_2d/datasets/detection_dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/datasets/transforms.py
+++ b/src/opendr/perception/object_detection_2d/datasets/transforms.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/datasets/wider_face.py
+++ b/src/opendr/perception/object_detection_2d/datasets/wider_face.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/datasets/wider_person.py
+++ b/src/opendr/perception/object_detection_2d/datasets/wider_person.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/detr/algorithm/util/__init__.py
+++ b/src/opendr/perception/object_detection_2d/detr/algorithm/util/__init__.py
@@ -1,1 +1,1 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project

--- a/src/opendr/perception/object_detection_2d/detr/algorithm/util/draw.py
+++ b/src/opendr/perception/object_detection_2d/detr/algorithm/util/draw.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/detr/detr_learner.py
+++ b/src/opendr/perception/object_detection_2d/detr/detr_learner.py
@@ -1,4 +1,5 @@
-
+# Copyright 2020-2022 OpenDR European Project
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/src/opendr/perception/object_detection_2d/gem/algorithm/engine.py
+++ b/src/opendr/perception/object_detection_2d/gem/algorithm/engine.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# Modifications Copyright 2021 - present, OpenDR European Project
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/gem/algorithm/engine.py
+++ b/src/opendr/perception/object_detection_2d/gem/algorithm/engine.py
@@ -1,5 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-# Modifications Copyright 2021 - present, OpenDR European Project
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/gem/algorithm/util/draw.py
+++ b/src/opendr/perception/object_detection_2d/gem/algorithm/util/draw.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/gem/algorithm/util/sampler.py
+++ b/src/opendr/perception/object_detection_2d/gem/algorithm/util/sampler.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/gem/gem_learner.py
+++ b/src/opendr/perception/object_detection_2d/gem/gem_learner.py
@@ -1,5 +1,5 @@
-# Copyright 2020-2021 OpenDR European Project
-
+# Copyright 2020-2022 OpenDR European Project
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/src/opendr/perception/object_detection_2d/retinaface/retinaface_learner.py
+++ b/src/opendr/perception/object_detection_2d/retinaface/retinaface_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/ssd/ssd_learner.py
+++ b/src/opendr/perception/object_detection_2d/ssd/ssd_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/utils/eval_utils.py
+++ b/src/opendr/perception/object_detection_2d/utils/eval_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/utils/get_color_infra_alignment.py
+++ b/src/opendr/perception/object_detection_2d/utils/get_color_infra_alignment.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/utils/vis_utils.py
+++ b/src/opendr/perception/object_detection_2d/utils/vis_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_2d/yolov3/yolov3_learner.py
+++ b/src/opendr/perception/object_detection_2d/yolov3/yolov3_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_3d/datasets/create_data_kitti.py
+++ b/src/opendr/perception/object_detection_3d/datasets/create_data_kitti.py
@@ -1,3 +1,4 @@
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_3d/datasets/kitti.py
+++ b/src/opendr/perception/object_detection_3d/datasets/kitti.py
@@ -1,3 +1,4 @@
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/logger.py
+++ b/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/logger.py
@@ -1,3 +1,4 @@
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/second_detector/load.py
+++ b/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/second_detector/load.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/second_detector/run.py
+++ b/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/second_detector/run.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/voxel_object_detection_3d_learner.py
+++ b/src/opendr/perception/object_detection_3d/voxel_object_detection_3d/voxel_object_detection_3d_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Aristotle University of Thessaloniki
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_2d/datasets/market1501_dataset.py
+++ b/src/opendr/perception/object_tracking_2d/datasets/market1501_dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_2d/datasets/mot_dataset.py
+++ b/src/opendr/perception/object_tracking_2d/datasets/mot_dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_2d/deep_sort/algorithm/deep_sort_tracker.py
+++ b/src/opendr/perception/object_tracking_2d/deep_sort/algorithm/deep_sort_tracker.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_2d/deep_sort/algorithm/run.py
+++ b/src/opendr/perception/object_tracking_2d/deep_sort/algorithm/run.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_2d/deep_sort/object_tracking_2d_deep_sort_learner.py
+++ b/src/opendr/perception/object_tracking_2d/deep_sort/object_tracking_2d_deep_sort_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_2d/fair_mot/algorithm/load.py
+++ b/src/opendr/perception/object_tracking_2d/fair_mot/algorithm/load.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_2d/fair_mot/algorithm/run.py
+++ b/src/opendr/perception/object_tracking_2d/fair_mot/algorithm/run.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_2d/fair_mot/object_tracking_2d_fair_mot_learner.py
+++ b/src/opendr/perception/object_tracking_2d/fair_mot/object_tracking_2d_fair_mot_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_2d/logger.py
+++ b/src/opendr/perception/object_tracking_2d/logger.py
@@ -1,4 +1,5 @@
-
+# Copyright 2020-2022 OpenDR European Project
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/src/opendr/perception/object_tracking_3d/ab3dmot/algorithm/ab3dmot.py
+++ b/src/opendr/perception/object_tracking_3d/ab3dmot/algorithm/ab3dmot.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_3d/ab3dmot/algorithm/evaluate.py
+++ b/src/opendr/perception/object_tracking_3d/ab3dmot/algorithm/evaluate.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_3d/ab3dmot/algorithm/kalman_tracker_3d.py
+++ b/src/opendr/perception/object_tracking_3d/ab3dmot/algorithm/kalman_tracker_3d.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_3d/ab3dmot/logger.py
+++ b/src/opendr/perception/object_tracking_3d/ab3dmot/logger.py
@@ -1,3 +1,4 @@
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_3d/ab3dmot/object_tracking_3d_ab3dmot_learner.py
+++ b/src/opendr/perception/object_tracking_3d/ab3dmot/object_tracking_3d_ab3dmot_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/object_tracking_3d/datasets/kitti_tracking.py
+++ b/src/opendr/perception/object_tracking_3d/datasets/kitti_tracking.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/panoptic_segmentation/datasets/cityscapes.py
+++ b/src/opendr/perception/panoptic_segmentation/datasets/cityscapes.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/panoptic_segmentation/datasets/kitti.py
+++ b/src/opendr/perception/panoptic_segmentation/datasets/kitti.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/panoptic_segmentation/efficient_ps/configs/singlegpu_sample.py
+++ b/src/opendr/perception/panoptic_segmentation/efficient_ps/configs/singlegpu_sample.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/panoptic_segmentation/efficient_ps/efficient_ps_learner.py
+++ b/src/opendr/perception/panoptic_segmentation/efficient_ps/efficient_ps_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/pose_estimation/lightweight_open_pose/algorithm/models/with_mobilenet_v2.py
+++ b/src/opendr/perception/pose_estimation/lightweight_open_pose/algorithm/models/with_mobilenet_v2.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/pose_estimation/lightweight_open_pose/algorithm/models/with_shufflenet.py
+++ b/src/opendr/perception/pose_estimation/lightweight_open_pose/algorithm/models/with_shufflenet.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/pose_estimation/lightweight_open_pose/filtered_pose.py
+++ b/src/opendr/perception/pose_estimation/lightweight_open_pose/filtered_pose.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/pose_estimation/lightweight_open_pose/lightweight_open_pose_learner.py
+++ b/src/opendr/perception/pose_estimation/lightweight_open_pose/lightweight_open_pose_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/pose_estimation/lightweight_open_pose/utilities.py
+++ b/src/opendr/perception/pose_estimation/lightweight_open_pose/utilities.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/semantic_segmentation/bisenet/CamVid.py
+++ b/src/opendr/perception/semantic_segmentation/bisenet/CamVid.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/semantic_segmentation/bisenet/bisenet_learner.py
+++ b/src/opendr/perception/semantic_segmentation/bisenet/bisenet_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/skeleton_based_action_recognition/progressive_spatio_temporal_gcn_learner.py
+++ b/src/opendr/perception/skeleton_based_action_recognition/progressive_spatio_temporal_gcn_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/skeleton_based_action_recognition/spatio_temporal_gcn_learner.py
+++ b/src/opendr/perception/skeleton_based_action_recognition/spatio_temporal_gcn_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/speech_recognition/edgespeechnets/algorithm/audioutils.py
+++ b/src/opendr/perception/speech_recognition/edgespeechnets/algorithm/audioutils.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Tampere University
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/speech_recognition/edgespeechnets/algorithm/models.py
+++ b/src/opendr/perception/speech_recognition/edgespeechnets/algorithm/models.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Tampere University
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/speech_recognition/edgespeechnets/edgespeechnets_learner.py
+++ b/src/opendr/perception/speech_recognition/edgespeechnets/edgespeechnets_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/speech_recognition/matchboxnet/algorithm/audioutils.py
+++ b/src/opendr/perception/speech_recognition/matchboxnet/algorithm/audioutils.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Tampere University
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/speech_recognition/matchboxnet/algorithm/model.py
+++ b/src/opendr/perception/speech_recognition/matchboxnet/algorithm/model.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Tampere University
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/speech_recognition/matchboxnet/matchboxnet_learner.py
+++ b/src/opendr/perception/speech_recognition/matchboxnet/matchboxnet_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/speech_recognition/quadraticselfonn/algorithm/audioutils.py
+++ b/src/opendr/perception/speech_recognition/quadraticselfonn/algorithm/audioutils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/speech_recognition/quadraticselfonn/algorithm/model.py
+++ b/src/opendr/perception/speech_recognition/quadraticselfonn/algorithm/model.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/perception/speech_recognition/quadraticselfonn/quadraticselfonn_learner.py
+++ b/src/opendr/perception/speech_recognition/quadraticselfonn/quadraticselfonn_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/simulation/human_model_generation/pifu_generator_learner.py
+++ b/src/opendr/simulation/human_model_generation/pifu_generator_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/simulation/human_model_generation/utilities/config_utils.py
+++ b/src/opendr/simulation/human_model_generation/utilities/config_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/simulation/human_model_generation/utilities/joint_extractor.py
+++ b/src/opendr/simulation/human_model_generation/utilities/joint_extractor.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/simulation/human_model_generation/utilities/model_3D.py
+++ b/src/opendr/simulation/human_model_generation/utilities/model_3D.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/simulation/human_model_generation/utilities/studio.py
+++ b/src/opendr/simulation/human_model_generation/utilities/studio.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/simulation/human_model_generation/utilities/visualizer.py
+++ b/src/opendr/simulation/human_model_generation/utilities/visualizer.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/utils/hyperparameter_tuner/dummy_learner.py
+++ b/src/opendr/utils/hyperparameter_tuner/dummy_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/utils/hyperparameter_tuner/hyperparameter_tuner.py
+++ b/src/opendr/utils/hyperparameter_tuner/hyperparameter_tuner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/opendr/utils/io.py
+++ b/src/opendr/utils/io.py
@@ -1,4 +1,4 @@
-# Copyright 2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2021 OpenDR project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/c_api/test_face_recognition.c
+++ b/tests/sources/c_api/test_face_recognition.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/sources/c_api/test_fmp_gmapping.cpp
+++ b/tests/sources/c_api/test_fmp_gmapping.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/sources/c_api/test_opendr_utils.c
+++ b/tests/sources/c_api/test_opendr_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 OpenDR project
+ * Copyright 2020-2022 OpenDR European Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/sources/tools/control/mobile_manipulation/test_mobile_manipulation.py
+++ b/tests/sources/tools/control/mobile_manipulation/test_mobile_manipulation.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/control/single_demo_grasp/test_single_demo_grasp.py
+++ b/tests/sources/tools/control/single_demo_grasp/test_single_demo_grasp.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/activity_recognition/cox3d/test_cox3d_learner.py
+++ b/tests/sources/tools/perception/activity_recognition/cox3d/test_cox3d_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/activity_recognition/x3d/test_x3d_learner.py
+++ b/tests/sources/tools/perception/activity_recognition/x3d/test_x3d_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/compressive_learning/multilinear_compressive_learning/test_multilinear_compressive_learner.py
+++ b/tests/sources/tools/perception/compressive_learning/multilinear_compressive_learning/test_multilinear_compressive_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/face_recognition/test_face_recognition.py
+++ b/tests/sources/tools/perception/face_recognition/test_face_recognition.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/test_pstbln.py
+++ b/tests/sources/tools/perception/facial_expression_recognition/landmark_based_facial_expression_recognition/test_pstbln.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/heart_anomaly_detection/attention_neural_bag_of_feature/test_attention_neural_bag_of_feature_learner.py
+++ b/tests/sources/tools/perception/heart_anomaly_detection/attention_neural_bag_of_feature/test_attention_neural_bag_of_feature_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/heart_anomaly_detection/gated_recurrent_unit/test_gated_recurrent_unit_learner.py
+++ b/tests/sources/tools/perception/heart_anomaly_detection/gated_recurrent_unit/test_gated_recurrent_unit_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/multimodal_human_centric/rgbd_hand_gesture_learner/test_rgbd_hand_gesture_learner.py
+++ b/tests/sources/tools/perception/multimodal_human_centric/rgbd_hand_gesture_learner/test_rgbd_hand_gesture_learner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/object_detection_2d/centernet/test_centernet.py
+++ b/tests/sources/tools/perception/object_detection_2d/centernet/test_centernet.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/object_detection_2d/detr/test_detr.py
+++ b/tests/sources/tools/perception/object_detection_2d/detr/test_detr.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/object_detection_2d/gem/test_gem.py
+++ b/tests/sources/tools/perception/object_detection_2d/gem/test_gem.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/object_detection_2d/retinaface/test_retinaface.py
+++ b/tests/sources/tools/perception/object_detection_2d/retinaface/test_retinaface.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/object_detection_2d/ssd/test_ssd.py
+++ b/tests/sources/tools/perception/object_detection_2d/ssd/test_ssd.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/object_detection_2d/yolov3/test_yolo3.py
+++ b/tests/sources/tools/perception/object_detection_2d/yolov3/test_yolo3.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/object_detection_3d/voxel_object_detection_3d/test_object_detection_3d.py
+++ b/tests/sources/tools/perception/object_detection_3d/voxel_object_detection_3d/test_object_detection_3d.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/object_tracking_2d/deep_sort/test_object_tracking_2d_deep_sort.py
+++ b/tests/sources/tools/perception/object_tracking_2d/deep_sort/test_object_tracking_2d_deep_sort.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/object_tracking_2d/fair_mot/test_object_tracking_2d_fair_mot.py
+++ b/tests/sources/tools/perception/object_tracking_2d/fair_mot/test_object_tracking_2d_fair_mot.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/object_tracking_3d/ab3dmot/test_object_tracking_3d_ab3dmot.py
+++ b/tests/sources/tools/perception/object_tracking_3d/ab3dmot/test_object_tracking_3d_ab3dmot.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/pose_estimation/lightweight_open_pose/test_lightweight_open_pose.py
+++ b/tests/sources/tools/perception/pose_estimation/lightweight_open_pose/test_lightweight_open_pose.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/semantic_segmentation/bisenet/test_semantic_segmentation_bisenet.py
+++ b/tests/sources/tools/perception/semantic_segmentation/bisenet/test_semantic_segmentation_bisenet.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/skeleton_based_action_recognition/test_pstgcn.py
+++ b/tests/sources/tools/perception/skeleton_based_action_recognition/test_pstgcn.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/skeleton_based_action_recognition/test_stbln.py
+++ b/tests/sources/tools/perception/skeleton_based_action_recognition/test_stbln.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/skeleton_based_action_recognition/test_stgcn.py
+++ b/tests/sources/tools/perception/skeleton_based_action_recognition/test_stgcn.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/skeleton_based_action_recognition/test_tagcn.py
+++ b/tests/sources/tools/perception/skeleton_based_action_recognition/test_tagcn.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/speech_recognition/edgespeechnets/test_edgespeechnets.py
+++ b/tests/sources/tools/perception/speech_recognition/edgespeechnets/test_edgespeechnets.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/speech_recognition/matchboxnet/test_matchboxnet.py
+++ b/tests/sources/tools/perception/speech_recognition/matchboxnet/test_matchboxnet.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/perception/speech_recognition/quadraticselfonn/test_quadraticselfonn.py
+++ b/tests/sources/tools/perception/speech_recognition/quadraticselfonn/test_quadraticselfonn.py
@@ -1,4 +1,4 @@
-# Copyright 1996-2020 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/simulation/human_model_generation/test_human_model_generation.py
+++ b/tests/sources/tools/simulation/human_model_generation/test_human_model_generation.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/utils/test_hyperparameter_tuner.py
+++ b/tests/sources/tools/utils/test_hyperparameter_tuner.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR European Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/sources/tools/utils/test_io.py
+++ b/tests/sources/tools/utils/test_io.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 OpenDR Project
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2020-2021 Cyberbotics Ltd.
+# Copyright 2020-2022 OpenDR European Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,10 +19,14 @@
 import unittest
 import os
 import fnmatch
+import datetime
 
 from io import open
 
-APACHE2_LICENSE_C = """* Licensed under the Apache License, Version 2.0 (the "License");
+APACHE2_LICENSE_C = """/*
+ * Copyright 2020-20XX OpenDR European Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -33,9 +37,11 @@ APACHE2_LICENSE_C = """* Licensed under the Apache License, Version 2.0 (the "Li
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */"""
+ */""".replace('20XX', str(datetime.datetime.now().year))
 
-APACHE2_LICENSE_CPP = """// Licensed under the Apache License, Version 2.0 (the "License");
+APACHE2_LICENSE_CPP = """// Copyright 2020-20XX OpenDR European Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -45,9 +51,10 @@ APACHE2_LICENSE_CPP = """// Licensed under the Apache License, Version 2.0 (the 
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License."""
+// limitations under the License.""".replace('20XX', str(datetime.datetime.now().year))
 
-APACHE2_LICENSE_PYTHON = """
+APACHE2_LICENSE_PYTHON = """# Copyright 2020-20XX OpenDR European Project
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -58,7 +65,7 @@ APACHE2_LICENSE_PYTHON = """
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License."""
+# limitations under the License.""".replace('20XX', str(datetime.datetime.now().year))
 
 PYTHON_OPTIONAL_HEADERS = [
     '#!/usr/bin/env python2',
@@ -93,6 +100,10 @@ class TestLicense(unittest.TestCase):
             'src/opendr/perception/skeleton_based_action_recognition/algorithm',
             'src/opendr/perception/semantic_segmentation/bisenet/algorithm',
             'src/opendr/perception/object_detection_2d/retinaface/algorithm',
+            'src/opendr/perception/object_detection_2d/gem/algorithm',
+            'src/opendr/perception/object_detection_2d/detr/algorithm',
+            'src/opendr/perception/speech_recognition/edgespeechnets/algorithm',
+            'src/opendr/perception/speech_recognition/matchboxnet/algorithm',
             'src/opendr/perception/panoptic_segmentation/efficient_ps/algorithm/EfficientPS',
             'src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition',
             'projects/control/eagerx/eagerx',
@@ -102,7 +113,7 @@ class TestLicense(unittest.TestCase):
             'src/opendr/perception/activity_recognition/datasets/utils/decoder.py',
             'projects/perception/lightweight_open_pose/jetbot/utils/pid.py',
             'src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/trainers.py',
-            'src/opendr/perception/object_detection_2d/retinaface/Makefile'
+            'src/opendr/perception/object_detection_2d/retinaface/Makefile',
         ]
 
         skippedDirectories = [

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -102,8 +102,6 @@ class TestLicense(unittest.TestCase):
             'src/opendr/perception/object_detection_2d/retinaface/algorithm',
             'src/opendr/perception/object_detection_2d/gem/algorithm',
             'src/opendr/perception/object_detection_2d/detr/algorithm',
-            'src/opendr/perception/speech_recognition/edgespeechnets/algorithm',
-            'src/opendr/perception/speech_recognition/matchboxnet/algorithm',
             'src/opendr/perception/panoptic_segmentation/efficient_ps/algorithm/EfficientPS',
             'src/opendr/perception/facial_expression_recognition/landmark_based_facial_expression_recognition',
             'projects/control/eagerx/eagerx',

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -113,7 +113,7 @@ class TestLicense(unittest.TestCase):
             'src/opendr/perception/activity_recognition/datasets/utils/decoder.py',
             'projects/perception/lightweight_open_pose/jetbot/utils/pid.py',
             'src/opendr/perception/compressive_learning/multilinear_compressive_learning/algorithm/trainers.py',
-            'src/opendr/perception/object_detection_2d/retinaface/Makefile',
+            'src/opendr/perception/object_detection_2d/retinaface/Makefile'
         ]
 
         skippedDirectories = [


### PR DESCRIPTION
**Description**
This PR updates the copyright date and enforces the same rights holder (`OpenDR European Project`). Some said nothing, others just OpenDR. 
There were some attributions where the copyright holder was marked as the partner itself, for which I need a confirmation from the relevant partner to know if that contribution was made within the OpenDR context and therefore can simply be renamed as such or if those files should be instead added as exception. 

I didn't tag everyone, so if you see somebody missing please tag anybody that is relevant.

Changes requiring validation (**put a checkmark if the change done is validated**):

**Aarhus University:** @iliiliiliili

As it is part of the demo, I assumed they were done in the context of OpenDR so I changed the rights holder from `Aarhus University` to `OpenDR`. Can you validate the change? Or should it be reverted and an exception added?

- [x] projects/perception/object_detection_3d/demos/voxel_object_detection_3d/data_generators.py
- [x] projects/perception/object_detection_3d/demos/voxel_object_detection_3d/draw_point_clouds.py 
- [x] projects/perception/object_detection_3d/demos/voxel_object_detection_3d/metrics.py 
- [x] projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/channel.py
- [x] projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/main.py
- [x] projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/o3m_lidar.py
- [x] projects/perception/object_detection_3d/demos/voxel_object_detection_3d/o3m_lidar/structures.py
- [x] projects/perception/object_detection_3d/demos/voxel_object_detection_3d/rplidar_processor.py

**Aristotle University of Thessaloniki:** @passalis @Pavlos-Tosidis 

For the most part they appear (correct me if I'm wrong) to be contibutions to the OpenDR framework, so I changed from `Aristotle University of Thessaloniki` to `OpenDR`. Can you validate the change? Or should it be reverted and an exception added?

- [x] projects/simulation/human_dataset_generation/background.py
- [x] projects/simulation/human_dataset_generation/create_background_images.py
- [x] projects/simulation/human_dataset_generation/create_dataset.py
- [x] projects/simulation/human_dataset_generation/data_generator.py
- [x] projects/simulation/human_dataset_generation/reformat_cityscapes.py
- [x] src/opendr/engine/constants.py
- [x] src/opendr/engine/data.py
- [x] src/opendr/engine/datasets.py
- [x] src/opendr/engine/example_learner.py
- [x] src/opendr/engine/learners.py
- [x] src/opendr/engine/target.py
- [x] src/opendr/perception/object_detection_3d/voxel_object_detection_3d/voxel_object_detection_3d_learner.py (@iliiliiliili  probably wrong header)

**Delft University of Technology:**
@jelledouwe 
Files in these folders are attributed to Facebook, with some mentioning minor modifications from OpenDR, so I've added an exception to the `test_license` for these folders (i.e I didn't change the license attribution currently provided). From you I just need to double check everything is coherent copyright wise, or if some should be changed based on whether they are your original contribution instead.

- [x] 'src/opendr/perception/object_detection_2d/gem/algorithm',
- [x] 'src/opendr/perception/object_detection_2d/detr/algorithm',

**Tampere University:** 
@anton-muravev @JenniRaitoharju 

Files in these folders are attributed to `Tampere University`. Since they are in the `algorithm` folder I assumed they pre-existed and therefore weren't done in the context of OpenDR. Hence for now I've just added an exception to the `test_license` and maintained Tampere as the rights owner. Am I correct or should they be changed to OpenDR?

- [x] 'src/opendr/perception/speech_recognition/edgespeechnets/algorithm',
- [x] 'src/opendr/perception/speech_recognition/matchboxnet/algorithm',