### PR TITLE
Make `test release` docker target the specific branch when the label is run manually

### DIFF
--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -42,8 +42,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Get branch name
+      id: branch-name
+      uses: tj-actions/branch-names@v5.1
     - name: Build Docker Image
-      run: docker build --tag opendr-toolkit:cpu_$OPENDR_VERSION --file Dockerfile .
+      run: docker build --tag opendr-toolkit:cpu_$OPENDR_VERSION --build-arg branch=${{ steps.branch-name.outputs.current_branch }} --file Dockerfile .
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
@@ -59,8 +62,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Get branch name
+      id: branch-name
+      uses: tj-actions/branch-names@v5.1
     - name: Build Docker Image
-      run: docker build --tag opendr-toolkit:cuda_$OPENDR_VERSION --file Dockerfile-cuda .
+      run: docker build --tag opendr-toolkit:cuda_$OPENDR_VERSION --build-arg branch=${{ steps.branch-name.outputs.current_branch }} --file Dockerfile-cuda .
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -139,8 +139,14 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Get branch name
+      id: branch-name
+      uses: tj-actions/branch-names@v5.1
     - name: Build image
       run: |
+        cat Dockerfile
+        sed -i 's/# %branch-name-template%/-b ${{ steps.branch-name.outputs.current_branch }}/' Dockerfile
+        cat Dockerfile
         docker build --tag opendr/opendr-toolkit:cpu_test --file Dockerfile .
         docker save opendr/opendr-toolkit:cpu_test > cpu_test.zip
     - name: Upload image artifact

--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -144,10 +144,7 @@ jobs:
       uses: tj-actions/branch-names@v5.1
     - name: Build image
       run: |
-        cat Dockerfile
-        sed -i 's/# %branch-name-template%/-b ${{ steps.branch-name.outputs.current_branch }}/' Dockerfile
-        cat Dockerfile
-        docker build --tag opendr/opendr-toolkit:cpu_test --file Dockerfile .
+        docker build --tag opendr/opendr-toolkit:cpu_test --build-arg branch=${{ steps.branch-name.outputs.current_branch }} --file Dockerfile .
         docker save opendr/opendr-toolkit:cpu_test > cpu_test.zip
     - name: Upload image artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/tests_suite_develop.yml
+++ b/.github/workflows/tests_suite_develop.yml
@@ -143,9 +143,12 @@ jobs:
       with:
         submodules: true
         ref: develop
+    - name: Get branch name
+      id: branch-name
+      uses: tj-actions/branch-names@v5.1
     - name: Build image
       run: |
-        docker build --tag opendr/opendr-toolkit:cpu_test --file Dockerfile .
+        docker build --tag opendr/opendr-toolkit:cpu_test --build-arg branch=${{ steps.branch-name.outputs.current_branch }} --file Dockerfile .
         docker save opendr/opendr-toolkit:cpu_test > cpu_test.zip
     - name: Upload image artifact
       uses: actions/upload-artifact@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ARG BRANCH
+ARG branch
 
 # Install dependencies
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:20.04
 
+ARG BRANCH
+
 # Install dependencies
 RUN apt-get update && \
     apt-get --yes install git sudo
@@ -12,7 +14,7 @@ RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--"]
 
 # Clone the repo and install the toolkit
-RUN git clone --depth 1 --recurse-submodules -j8 https://github.com/opendr-eu/opendr # %branch-name-template%
+RUN git clone --depth 1 --recurse-submodules -j8 https://github.com/opendr-eu/opendr -b $branch
 WORKDIR "/opendr"
 RUN ./bin/install.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--"]
 
 # Clone the repo and install the toolkit
-RUN git clone --depth 1 --recurse-submodules -j8 https://github.com/opendr-eu/opendr
+RUN git clone --depth 1 --recurse-submodules -j8 https://github.com/opendr-eu/opendr # %branch-name-template%
 WORKDIR "/opendr"
 RUN ./bin/install.sh
 

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -1,5 +1,7 @@
 FROM nvidia/cuda:11.0-base
 
+ARG branch
+
 # Install dependencies
 RUN apt-get update && \
     apt-get --yes install git sudo apt-utils
@@ -43,7 +45,7 @@ RUN sudo apt-get --yes install build-essential && \
 
 # Clone the repo and install the toolkit
 ENV OPENDR_DEVICE gpu
-RUN git clone --depth 1 --recurse-submodules -j8 https://github.com/opendr-eu/opendr
+RUN git clone --depth 1 --recurse-submodules -j8 https://github.com/opendr-eu/opendr -b $branch
 WORKDIR "/opendr"
 RUN ./bin/install.sh
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please follow the instructions provided in the [wiki](https://github.com/tasoste
 ## How to cite us
 If you use OpenDR for your research, please cite the following paper that introduces OpenDR architecture and design:
 <pre>
-@article{passalis2022opendr,
+@article{opendr2022,
   title={OpenDR: An Open Toolkit for Enabling High Performance, Low Footprint Deep Learning for Robotics},
   author={Passalis, Nikolaos and Pedrazzi, Stefania and Babuska, Robert and Burgard, Wolfram and Dias, Daniel and Ferro, Francesco and Gabbouj, Moncef and Green, Ole and Iosifidis, Alexandros and Kayacan, Erdal and Kober, Jens and Michel, Olivier and Nikolaidis, Nikos and Nousi, Paraskevi and Pieters, Roel and Tzelepi, Maria and Valada, Abhinav and Tefas, Anastasios},
   journal={arXiv preprint arXiv:2203.00403},


### PR DESCRIPTION
As emerged in https://github.com/opendr-eu/opendr/pull/237, when adding new tools the `test release` label is not very useful to test the docker images built from a specific branch. The reason is that currently the dockerfile clones the main repo, and not the specific branch in which we triggered the label. So far this has entailed manually editing the dockerfile prior to running the test, and removing the change before merging which isn't very practical.

The nightly docker tests do catch the issues, if any, but it would be better to know of it prior to merging.