### PR TITLE
Fix nvidia docker key

### DIFF
--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -3,9 +3,9 @@ FROM nvidia/cuda:11.2.0-cudnn8-devel-ubuntu20.04
 ARG branch
 
 # Fix NVIDIA CUDA Linux repository key rotation
-RUN apt-key del 7fa2af80
-ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/3bf863cc.pub
+# RUN apt-key del 7fa2af80
+# ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+# RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/3bf863cc.pub
 
 # Install dependencies
 RUN apt-get update && \

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -2,6 +2,11 @@ FROM nvidia/cuda:11.2.0-cudnn8-devel-ubuntu20.04
 
 ARG branch
 
+# Fix NVIDIA CUDA Linux repository key rotation
+RUN apt-key del 7fa2af80
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/3bf863cc.pub
+
 # Install dependencies
 RUN apt-get update && \
     apt-get --yes install git sudo apt-utils


### PR DESCRIPTION
As reported by Thomas, the docker build process should fail due to outdated nvidia keys, as mentioned [here](https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772). This PR addresses the issue, and in practice I assume this PR https://github.com/opendr-eu/opendr/pull/195 might need to do something similar to the Dockerfile-embedded.