### PR TITLE
Panoptic segmentation: download pretrained weights in ROS node

### DIFF
--- a/projects/opendr_ws/src/perception/README.md
+++ b/projects/opendr_ws/src/perception/README.md
@@ -164,16 +164,16 @@ rosrun perception object_detection_2d_gem.py
 A ROS node for performing panoptic segmentation on a specified RGB image stream using the [EfficientPS](../../../../src/opendr/perception/panoptic_segmentation/README.md) network.
 Assuming that the OpenDR catkin workspace has been sourced, the node can be started with:
 ```shell
-rosrun perception panoptic_segmentation_efficient_ps.py IMAGE_TOPIC CHECKPOINT
+rosrun perception panoptic_segmentation_efficient_ps.py
 ```
-where `IMAGE_TOPIC` specifies the ROS topic, to which the node will subscribe.
-`CHECKPOINT` can be either one of ['cityscapes', 'kitti'] to download pre-trained model weights or a path to an existing checkpoint file.
 
-Additionally, the following optional arguments are available:
+The following optional arguments are available:
 - `-h, --help`: show a help message and exit
-- `--heamap_topic HEATMAP_TOPIC`: publish the semantic and instance maps on `HEATMAP_TOPIC`
-- `--visualization_topic VISUALIZATION_TOPIC`: publish the panoptic segmentation map as an RGB image on `VISUALIZATION_TOPIC` or a more detailed overview if using the `--detailed_visualization` flag
-- `--detailed_visualization`: generate a combined overview of the input RGB image and the semantic, instance, and panoptic segmentation maps
+- `--input_rgb_image_topic INPUT_RGB_IMAGE_TOPIC` : listen to RGB images on this topic (default=`/usb_cam/image_raw`)
+- `--checkpoint CHECKPOINT` : download pretrained models [cityscapes, kitti] or load from the provided path (default=`cityscapes`)
+- `--output_rgb_image_topic OUTPUT_RGB_IMAGE_TOPIC`: publish the semantic and instance maps on this topic as `OUTPUT_HEATMAP_TOPIC/semantic` and `OUTPUT_HEATMAP_TOPIC/instance` (default=`/opendir/panoptic`)
+- `--visualization_topic VISUALIZATION_TOPIC`: publish the panoptic segmentation map as an RGB image on `VISUALIZATION_TOPIC` or a more detailed overview if using the `--detailed_visualization` flag (default=`/opendr/panoptic/rgb_visualization`)
+- `--detailed_visualization`: generate a combined overview of the input RGB image and the semantic, instance, and panoptic segmentation maps and publish it on `OUTPUT_RGB_IMAGE_TOPIC` (default=deactivated)
 
 
 ## Semantic Segmentation ROS Node

--- a/projects/opendr_ws/src/perception/README.md
+++ b/projects/opendr_ws/src/perception/README.md
@@ -153,9 +153,10 @@ rosrun perception object_detection_2d_gem.py
 A ROS node for performing panoptic segmentation on a specified RGB image stream using the [EfficientPS](../../../../src/opendr/perception/panoptic_segmentation/README.md) network.
 Assuming that the OpenDR catkin workspace has been sourced, the node can be started with:
 ```shell
-rosrun perception panoptic_segmentation_efficient_ps.py CHECKPOINT IMAGE_TOPIC
+rosrun perception panoptic_segmentation_efficient_ps.py IMAGE_TOPIC CHECKPOINT
 ```
-with `CHECKPOINT` pointing to the path to the trained model weights and `IMAGE_TOPIC` specifying the ROS topic, to which the node will subscribe.
+where `IMAGE_TOPIC` specifies the ROS topic, to which the node will subscribe.
+`CHECKPOINT` can be either one of ['cityscapes', 'kitti'] to download pre-trained model weights or a path to an existing checkpoint file.
 
 Additionally, the following optional arguments are available:
 - `-h, --help`: show a help message and exit

--- a/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
+++ b/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
@@ -154,7 +154,7 @@ class EfficientPsNode:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('input_rgb_image_topic', type=str,
+    parser.add_argument('input_rgb_image_topic', type=str, default='/usb_cam/image_raw',
                         help='listen to RGB images on this topic')
     parser.add_argument('--checkpoint', type=str, default='cityscapes',
                         help='download pretrained models [cityscapes, kitti] or load from the provided path')

--- a/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
+++ b/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
@@ -97,7 +97,7 @@ class EfficientPsNode:
         """
         Subscribe to all relevant topics.
         """
-        rospy.Subscriber(self.input_rgb_image_topic, ROS_Image, self.callback)
+        rospy.Subscriber(self.input_rgb_image_topic, ROS_Image, self.callback, queue_size=1, buff_size=10000000)
 
     def _init_publisher(self):
         """

--- a/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
+++ b/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
@@ -66,7 +66,7 @@ class EfficientPsNode:
         self._learner = EfficientPsLearner(str(config_file))
 
         # Other
-        self._tmp_folder = Path(__file__).parent / 'tmp' / 'efficientps'
+        self._tmp_folder = Path(__file__).parent.parent / 'tmp' / 'efficientps'
         self._tmp_folder.mkdir(exist_ok=True, parents=True)
 
     def _init_learner(self) -> bool:

--- a/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
+++ b/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
@@ -67,15 +67,8 @@ class EfficientPsNode:
         self._learner = EfficientPsLearner(str(config_file))
 
         # Other
-        self._tmp_folder = Path(__file__).parent / 'efficientps_tmp'
-        self._tmp_folder.mkdir(exist_ok=True)
-
-    def __del__(self):
-        """
-        Remove temporary files.
-        """
-        shutil.rmtree(self._tmp_folder)
-        print('Shut down EfficientPS node and removed all temporary files.')
+        self._tmp_folder = Path(__file__).parent / 'tmp' / 'efficientps'
+        self._tmp_folder.mkdir(exist_ok=True, parents=True)
 
     def _init_learner(self) -> bool:
         """

--- a/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
+++ b/projects/opendr_ws/src/perception/scripts/panoptic_segmentation_efficient_ps.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import shutil
 import sys
 from pathlib import Path
 import argparse

--- a/src/opendr/engine/target.py
+++ b/src/opendr/engine/target.py
@@ -1068,6 +1068,14 @@ class Heatmap(Target):
         # Since this class stores the data as NumPy arrays, we can directly return the data.
         return self.data
 
+    def opencv(self):
+        """
+        Required to support the ros bridge for images.
+        :return: a NumPy-compatible representation of data
+        :rtype: numpy.ndarray
+        """
+        return self.numpy()
+
     def shape(self) -> Tuple[int, ...]:
         """
         Returns the shape of the underlying NumPy array.

--- a/src/opendr/perception/panoptic_segmentation/efficient_ps/efficient_ps_learner.py
+++ b/src/opendr/perception/panoptic_segmentation/efficient_ps/efficient_ps_learner.py
@@ -306,17 +306,18 @@ class EfficientPsLearner(Learner):
             warnings.warn('The current model has not been trained.')
         self.model.eval()
 
-        # Build the data pipeline
-        test_pipeline = Compose(self._cfg.test_pipeline[1:])
-        device = next(self.model.parameters()).device
-
-        # Convert to the format expected by the mmdetection API
         single_image_mode = False
         if isinstance(batch, Image):
             batch = [batch]
             single_image_mode = True
+
+        # Convert to the format expected by the mmdetection API
         mmdet_batch = []
+        device = next(self.model.parameters()).device
         for img in batch:
+            # Change the processing size according to the input image
+            self._cfg.test_pipeline[1:][0]['img_scale'] = batch[0].data.shape[1:]
+            test_pipeline = Compose(self._cfg.test_pipeline[1:])
             # Convert from OpenDR convention (CHW/RGB) to the expected format (HWC/BGR)
             img_ = img.convert('channels_last', 'bgr')
             mmdet_img = {'filename': None, 'img': img_, 'img_shape': img_.shape, 'ori_shape': img_.shape}

--- a/src/opendr/perception/panoptic_segmentation/efficient_ps/efficient_ps_learner.py
+++ b/src/opendr/perception/panoptic_segmentation/efficient_ps/efficient_ps_learner.py
@@ -481,8 +481,12 @@ class EfficientPsLearner(Learner):
 
             return update_to
 
-        with tqdm(unit='B', unit_scale=True, unit_divisor=1024, miniters=1, desc=f'Downloading {filename}') as pbar:
-            urllib.request.urlretrieve(url, filename, pbar_hook(pbar))
+        if os.path.exists(filename) and os.path.isfile(filename):
+            print(f'File already downloaded: {filename}')
+        else:
+            with tqdm(unit='B', unit_scale=True, unit_divisor=1024, miniters=1, desc=f'Downloading {filename}') \
+                    as pbar:
+                urllib.request.urlretrieve(url, filename, pbar_hook(pbar))
         return filename
 
     @staticmethod


### PR DESCRIPTION
Question to reviewers: Would it be okay to store the downloaded model weights somewhere to avoid re-downloading upon each start of the node? Now, they are removed when the node is stopped.

Changelog:
- add an option to download pre-trained models (KITTI, Cityscapes) when starting the node
- change the order of required parameters matching other nodes