### PR TITLE
Added Frame ID for visulaization purposes

### DIFF
--- a/projects/opendr_ws/src/perception/scripts/point_cloud_dataset.py
+++ b/projects/opendr_ws/src/perception/scripts/point_cloud_dataset.py
@@ -53,6 +53,8 @@ class PointCloudDatasetNode:
             message = self.bridge.to_ros_point_cloud(
                 point_cloud
             )
+            message.header.frame_id = "velodyne"
+
             self.output_point_cloud_publisher.publish(message)
 
             time.sleep(0.1)


### PR DESCRIPTION
# Description

Point cloud ROS node published data without frame id so it was not possible to visualize it on rviz. so I added frame id to the data.

## Type of change

-  [x] Quick Fix