### PR TITLE
Fix detectron2

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -48,7 +48,7 @@ if [[ "${OPENDR_DEVICE}" == "gpu" ]]; then
   echo "[INFO] Replacing torch==1.9.0+cu111 to enable CUDA acceleration."
   pip3 install torch==1.9.0+cu111 torchvision==0.10.0+cu111 torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
   echo "[INFO] Reinstalling detectronv2."
-  pip3 install 'git+https://github.com/facebookresearch/detectron2.git'
+  pip3 install 'git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13'
 fi
 
 make libopendr

--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -103,6 +103,10 @@ pip install mxnet-cu112==1.8.0post0
 pip install opendr-toolkit-engine
 pip install opendr-toolkit
 ```
+If you encounter any issue installing the latest version of detectron, then you can try installing a previous commit:
+```bash
+pip install 'git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13'
+```
 
 ## Installing only a *particular* tool using *pip* (CPU/GPU)
 

--- a/src/opendr/control/single_demo_grasp/Makefile
+++ b/src/opendr/control/single_demo_grasp/Makefile
@@ -25,7 +25,7 @@ install_runtime_dependencies:
 
 install_compilation_dependencies:
 	@+echo "#"; echo "# * Install Compilation Dependencies for single demonstration grasping *"; echo "#"
-	@+python3 -m pip install 'git+https://github.com/facebookresearch/detectron2.git'
+	@+python3 -m pip install 'git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13'
 	@./install_single_demo_grasp.sh
 
 help:

--- a/src/opendr/control/single_demo_grasp/dependencies.ini
+++ b/src/opendr/control/single_demo_grasp/dependencies.ini
@@ -13,4 +13,4 @@ python=torch==1.9.0
 
 opendr=opendr-toolkit-engine
 
-post-install=python3 -m pip install 'git+https://github.com/facebookresearch/detectron2.git'
+post-install=python3 -m pip install 'git+https://github.com/facebookresearch/detectron2.git@5aeb252b194b93dc2879b4ac34bc51a31b5aee13'


### PR DESCRIPTION
This PR updated the toolkit to points to a specific (and tested) commit of detectron2 in order to avoid breaking the installation when changes occur in detectron repository.