### PR TITLE
Docker scheduled tests update

### DIFF
--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -104,6 +104,6 @@ jobs:
         python-version: 3.8
     - name: Test Docker
       run: |
-        docker run --name toolkit -i opendr/opendr-toolkit:cpu_latest bash
+        docker run --name toolkit -i opendr/opendr-toolkit:cpu_v1.1.1 bash
         docker start toolkit
         docker exec -i toolkit bash -c "source bin/activate.sh && source tests/sources/tools/control/mobile_manipulation/run_ros.sh && python -m unittest discover -s tests/sources/tools/${{ matrix.package }}"

--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -162,18 +162,18 @@ source bin/activate.sh
 If you want to display GTK-based applications from the Docker container (e.g., visualize results using OpenCV `imshow()`), then you should mount the X server socket inside the container, e.g.,
 ```bash
 xhost +local:root
-sudo docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY opendr/opendr-toolkit:cpu_latest /bin/bash
+sudo docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY opendr/opendr-toolkit:cpu_v1.1.1 /bin/bash
 ```
 
 ## GPU docker
 If you want to use a CUDA-enabled container please install [nvidia-docker](https://github.com/NVIDIA/nvidia-docker).
 Then, you can directly run the latest image with the command:
 ```bash
-sudo docker run --gpus all -p 8888:8888 opendr/opendr-toolkit:cuda_latest
+sudo docker run --gpus all -p 8888:8888 opendr/opendr-toolkit:cuda_v1.1.1
 ```
 or, for an interactive session:
 ```bash
-sudo docker run --gpus all -it opendr/opendr-toolkit:cuda_latest /bin/bash
+sudo docker run --gpus all -it opendr/opendr-toolkit:cuda_v1.1.1 /bin/bash
 ```
 In this case, do not forget to enable the virtual environment with:
 ```bash


### PR DESCRIPTION
This PR updates the version of the image currently used in scheduled tests.

Currently, the tests fail since we are no longer have images tagged as `cpu_latest`:

`docker: Error response from daemon: manifest for opendr/opendr-toolkit:cpu_latest not found: manifest unknown: manifest unknown.`

This PR updates the docker image used to the latest available version. 
