### PR TITLE
Fix missing Python dependency in opendr-toolkit-object_detection_2d

### DIFF
--- a/src/opendr/perception/object_detection_2d/dependencies.ini
+++ b/src/opendr/perception/object_detection_2d/dependencies.ini
@@ -9,6 +9,7 @@ python=mxnet==1.8.0
        easydict
        gdown
        numba==0.53.0
+       tensorboardX>=2.0
 
 linux=libopenblas-dev
 


### PR DESCRIPTION
Address  #314:
When installing the pip package `opendr-toolkit-object_detection_2d` Python complaints that `tensorboardX` is not installed and it is not possible to use the module.

`tensorboardX` is used here:
https://github.com/opendr-eu/opendr/blob/56d398799f52cc60f8ce6efed19854c3485c38bb/src/opendr/perception/object_detection_2d/nms/seq2seq_nms/seq2seq_nms_learner.py#L32