### PR TITLE
ROS1 - Minor fixes

### DIFF
--- a/projects/opendr_ws/src/opendr_perception/scripts/object_tracking_2d_fair_mot_node.py
+++ b/projects/opendr_ws/src/opendr_perception/scripts/object_tracking_2d_fair_mot_node.py
@@ -192,7 +192,7 @@ def main():
                         type=str, default="cuda", choices=["cuda", "cpu"])
     parser.add_argument("-n", "--model_name", help="Name of the trained model",
                         type=str, default="fairmot_dla34", choices=["fairmot_dla34"])
-    parser.add_argument("-t", "--temp_dir", help="Path to a temporary directory with models",
+    parser.add_argument("-td", "--temp_dir", help="Path to a temporary directory with models",
                         type=str, default="temp")
     args = parser.parse_args()
 

--- a/projects/opendr_ws/src/opendr_perception/scripts/panoptic_segmentation_efficient_ps_node.py
+++ b/projects/opendr_ws/src/opendr_perception/scripts/panoptic_segmentation_efficient_ps_node.py
@@ -141,7 +141,7 @@ class EfficientPsNode:
             if self._visualization_publisher is not None and self._visualization_publisher.get_num_connections() > 0:
                 panoptic_image = EfficientPsLearner.visualize(image, prediction, show_figure=False,
                                                               detailed=self.detailed_visualization)
-                self._visualization_publisher.publish(self._bridge.to_ros_image(panoptic_image))
+                self._visualization_publisher.publish(self._bridge.to_ros_image(panoptic_image, encoding="rgb8"))
 
             if self._instance_heatmap_publisher is not None and self._instance_heatmap_publisher.get_num_connections() > 0:
                 self._instance_heatmap_publisher.publish(self._bridge.to_ros_image(prediction[0]))


### PR DESCRIPTION
Found a couple of small issues with two nodes:
1. A duplicate shortcut on object tracking 2d fair mot 
2. The visualization of panoptic segmentation didn't show on rqt due to bad encoding and threw this error:
    ```
    ImageView.callback_image() could not convert image from '8UC3' to 'rgb8' ([8UC3] is not a color format. but [rgb8] is. The conversion does not make sense)
    ```