### PR TITLE
ROS1 node fix duplicate argparse shortcut tracking3d

### DIFF
--- a/projects/opendr_ws/src/opendr_perception/scripts/object_tracking_3d_ab3dmot_node.py
+++ b/projects/opendr_ws/src/opendr_perception/scripts/object_tracking_3d_ab3dmot_node.py
@@ -126,7 +126,7 @@ def main():
             "car", "xyres_16.proto"
         )
     )
-    parser.add_argument("-t", "--temp_dir", help="Path to a temporary directory with models",
+    parser.add_argument("-td", "--temp_dir", help="Path to a temporary directory with models",
                         type=str, default="temp")
     args = parser.parse_args()
 


### PR DESCRIPTION
Another minor fix that i missed earlier for object tracking 3d ab3dmot ROS1 node. This stopped the node from running entirely.