### PR TITLE
Fix bug in GEM ROS2 node

### DIFF
--- a/projects/opendr_ws_2/src/opendr_perception/opendr_perception/object_detection_2d_gem_node.py
+++ b/projects/opendr_ws_2/src/opendr_perception/opendr_perception/object_detection_2d_gem_node.py
@@ -187,8 +187,8 @@ class ObjectDetectionGemNode(Node):
         self.gem_learner.download(path=".", verbose=True)
 
         # Subscribers
-        msg_rgb = message_filters.Subscriber(self, ROS_Image, input_rgb_image_topic, 1)
-        msg_ir = message_filters.Subscriber(self, ROS_Image, input_infra_image_topic, 1)
+        msg_rgb = message_filters.Subscriber(self, ROS_Image, input_rgb_image_topic)
+        msg_ir = message_filters.Subscriber(self, ROS_Image, input_infra_image_topic)
 
         sync = message_filters.TimeSynchronizer([msg_rgb, msg_ir], 1)
         sync.registerCallback(self.callback)


### PR DESCRIPTION
Cannot set qos_profile for message filter subscribers, therefore removing this argument.
Fixes #415 