### PR TITLE
Added unzip installation as base ubuntu dependency and tool tests fixes

### DIFF
--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -101,11 +101,7 @@ jobs:
         export ROS_DISTRO=noetic
         export OPENDR_HOME=$PWD
         ./bin/install.sh
-        pwd
-        pip -V
         source bin/activate.sh
-        pip -V
-        pip list
         python3 -m pip install -r tests/requirements.txt
         
         if [ ${{ matrix.package }} = "ctests" ]; then

--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -105,7 +105,9 @@ jobs:
         pip -V
         source bin/activate.sh
         pip -V
+        pip list
         python3 -m pip install -r tests/requirements.txt
+        
         if [ ${{ matrix.package }} = "ctests" ]; then
           make ctests
         else

--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -98,7 +98,6 @@ jobs:
         python-version: 3.8
     - name: Test Tools
       run: |
-        export DISABLE_BCOLZ_AVX2=true
         export ROS_DISTRO=noetic
         export OPENDR_HOME=$PWD
         ./bin/install.sh

--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -98,6 +98,7 @@ jobs:
         python-version: 3.8
     - name: Test Tools
       run: |
+        export DISABLE_BCOLZ_AVX2=true
         export ROS_DISTRO=noetic
         export OPENDR_HOME=$PWD
         ./bin/install.sh

--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -101,8 +101,11 @@ jobs:
         export ROS_DISTRO=noetic
         export OPENDR_HOME=$PWD
         ./bin/install.sh
+        pwd
+        pip -V
         source bin/activate.sh
-        python3 -m pip install -r tests/sources/requirements.txt
+        pip -V
+        python3 -m pip install -r tests/requirements.txt
         if [ ${{ matrix.package }} = "ctests" ]; then
           make ctests
         else

--- a/.github/workflows/tests_suite_develop.yml
+++ b/.github/workflows/tests_suite_develop.yml
@@ -43,7 +43,6 @@ jobs:
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
         export OPENDR_HOME=$PWD
-        export DISABLE_BCOLZ_AVX2=true
         export OPENDR_DEVICE=cpu
         pip install -r tests/requirements.txt
         python -m unittest discover -s tests

--- a/.github/workflows/tests_suite_develop.yml
+++ b/.github/workflows/tests_suite_develop.yml
@@ -43,6 +43,7 @@ jobs:
       run: |
         ${{ matrix.DEPENDENCIES_INSTALLATION }}
         export OPENDR_HOME=$PWD
+        export DISABLE_BCOLZ_AVX2=true
         export OPENDR_DEVICE=cpu
         pip install -r tests/requirements.txt
         python -m unittest discover -s tests

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -19,7 +19,7 @@ else
 fi
 
 # Install base ubuntu deps
-sudo apt-get install --yes libfreetype6-dev lsb-release git python3-pip curl wget python3.8-venv
+sudo apt-get install --yes unzip libfreetype6-dev lsb-release git python3-pip curl wget python3.8-venv
 
 # Get all submodules
 git submodule init

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -4,7 +4,7 @@ export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
 export PYTHON=python3
 export DISABLE_BCOLZ_AVX2=true
 
-pip3 install bcolz
+pip3 install bcolz-zipline
 exit 0
 if [[ -z "${OPENDR_DEVICE}" ]]; then
   echo "[INFO] Set available device to CPU. You can manually change this by running 'export OPENDR_DEVICE=gpu'."

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -4,8 +4,6 @@ export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
 export PYTHON=python3
 export DISABLE_BCOLZ_AVX2=true
 
-pip3 install bcolz-zipline
-exit 0
 if [[ -z "${OPENDR_DEVICE}" ]]; then
   echo "[INFO] Set available device to CPU. You can manually change this by running 'export OPENDR_DEVICE=gpu'."
   export OPENDR_DEVICE=cpu

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -4,6 +4,8 @@ export PYTHONPATH=$OPENDR_HOME/src:$PYTHONPATH
 export PYTHON=python3
 export DISABLE_BCOLZ_AVX2=true
 
+pip3 install bcolz
+exit 0
 if [[ -z "${OPENDR_DEVICE}" ]]; then
   echo "[INFO] Set available device to CPU. You can manually change this by running 'export OPENDR_DEVICE=gpu'."
   export OPENDR_DEVICE=cpu

--- a/src/opendr/control/single_demo_grasp/dependencies.ini
+++ b/src/opendr/control/single_demo_grasp/dependencies.ini
@@ -9,7 +9,7 @@ python=torch==1.13.1
        torchvision==0.14.1
        matplotlib>=2.2.2
        imgaug==0.4.0
-       pillow==8.3.2
+       pillow>=8.3.2,<10.0.0
        empy
 
 opendr=opendr-toolkit-engine

--- a/src/opendr/control/single_demo_grasp/dependencies.ini
+++ b/src/opendr/control/single_demo_grasp/dependencies.ini
@@ -9,7 +9,7 @@ python=torch==1.13.1
        torchvision==0.14.1
        matplotlib>=2.2.2
        imgaug==0.4.0
-       pillow>=8.3.2
+       pillow==8.3.2
        empy
 
 opendr=opendr-toolkit-engine

--- a/src/opendr/perception/face_recognition/dependencies.ini
+++ b/src/opendr/perception/face_recognition/dependencies.ini
@@ -3,7 +3,7 @@
 #  https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
 python=torch==1.13.1
        torchvision==0.14.1
-       bcolz>=1.2.1
+       bcolz-zipline
        protobuf<=3.20.0
        onnx==1.8.0
        onnxruntime==1.3.0

--- a/src/opendr/perception/object_detection_2d/dependencies.ini
+++ b/src/opendr/perception/object_detection_2d/dependencies.ini
@@ -14,7 +14,7 @@ python=mxnet==1.8.0
        seaborn
        ipython
        psutil
-       ultralytics==8.0.0
+       ultralytics-yolov5
 
 linux=libopenblas-dev
 

--- a/src/opendr/perception/object_detection_2d/dependencies.ini
+++ b/src/opendr/perception/object_detection_2d/dependencies.ini
@@ -14,7 +14,7 @@ python=mxnet==1.8.0
        seaborn
        ipython
        psutil
-       ultralytics==8.0.126
+       ultralytics==8.0.0
 
 linux=libopenblas-dev
 

--- a/src/opendr/perception/object_detection_2d/dependencies.ini
+++ b/src/opendr/perception/object_detection_2d/dependencies.ini
@@ -14,7 +14,7 @@ python=mxnet==1.8.0
        seaborn
        ipython
        psutil
-       ultralytics=8.0.126
+       ultralytics==8.0.126
 
 linux=libopenblas-dev
 

--- a/src/opendr/perception/object_detection_2d/dependencies.ini
+++ b/src/opendr/perception/object_detection_2d/dependencies.ini
@@ -14,7 +14,7 @@ python=mxnet==1.8.0
        seaborn
        ipython
        psutil
-       ultralytics
+       ultralytics=8.0.126
 
 linux=libopenblas-dev
 


### PR DESCRIPTION
Fixes: 
- Possible fix #453.
- Replaced `bcolz` with `bcolz-zipline` to fix broken installation
- [In tests_suite.yml](https://github.com/opendr-eu/opendr/blob/e3ed0a2117a31e747b1c087896045d01f0e89f5d/.github/workflows/tests_suite.yml#L105) fixed a call for `pip install /tests/sources/requirements.txt` which is an empty file to `pip install /tests/requirements.txt` which seems to be the correct one
- More strict pillow version, added <10.0.0, which breaks calls to `LINEAR` from detectron2 (which itself sits at an older version, newer versions have fixed this)
- Changed `ultralytics` requirement to `ultralytics-yolov5`  requirement in object_detection_2d requirements file

Created the branch off master since it seems develop and master are not yet synchronized after latest release, let me know if this needs changing.

