### PR TITLE
Apply cuDNN init fix to all Object Detectors 2D

### DIFF
--- a/projects/python/perception/object_detection_2d/yolov5/webcam_demo.py
+++ b/projects/python/perception/object_detection_2d/yolov5/webcam_demo.py
@@ -16,8 +16,6 @@ import argparse
 
 import cv2
 import time
-# Importing torch to avoid "RuntimeError: cuDNN error: CUDNN_STATUS_NOT_INITIALIZED" error
-import torch
 
 from opendr.engine.data import Image
 from opendr.perception.object_detection_2d import YOLOv5DetectorLearner
@@ -46,7 +44,6 @@ class VideoReader(object):
 
 
 if __name__ == '__main__':
-    torch.__version__  # Dummy usage of torch to avoid imported but not used pyflakes error
     parser = argparse.ArgumentParser()
     parser.add_argument("--device", help="Device to use (cpu, cuda)", type=str, default="cuda", choices=["cpu", "cuda"])
     parser.add_argument("--model", help="Model to use", type=str, default="yolov5s",

--- a/src/opendr/perception/object_detection_2d/__init__.py
+++ b/src/opendr/perception/object_detection_2d/__init__.py
@@ -1,3 +1,5 @@
+import torch  # Importing torch to avoid "RuntimeError: cuDNN error: CUDNN_STATUS_NOT_INITIALIZED" error
+
 from opendr.perception.object_detection_2d.centernet.centernet_learner import CenterNetDetectorLearner
 from opendr.perception.object_detection_2d.detr.detr_learner import DetrLearner
 from opendr.perception.object_detection_2d.gem.gem_learner import GemLearner
@@ -19,6 +21,7 @@ from opendr.perception.object_detection_2d.nms.soft_nms.soft_nms import SoftNMS
 from opendr.perception.object_detection_2d.nms.seq2seq_nms.seq2seq_nms_learner import Seq2SeqNMSLearner
 from opendr.perception.object_detection_2d.nms.fseq2_nms.fseq2_nms_learner import FSeq2NMSLearner
 
+torch.__version__  # NOQA Dummy usage of torch to avoid imported but not used pyflakes error
 __all__ = ['CenterNetDetectorLearner', 'DetrLearner', 'GemLearner', 'RetinaFaceLearner', 'SingleShotDetectorLearner',
            'YOLOv3DetectorLearner', 'NanodetLearner', 'WiderPersonDataset', 'WiderFaceDataset', 'transforms',
            'draw_bounding_boxes', 'ClusterNMS', 'FastNMS', 'SoftNMS', 'Seq2SeqNMSLearner', 'FSeq2NMSLearner',


### PR DESCRIPTION
It seems that the fix applied to yolov5 webcam demo for the cudnn not initialized error (#466), needs to be applied to all object detectors 2D, as i encountered it when running other demos too.

I removed the fix from the webcam demo and added it to the `object_detectors_2d` module `__init__.py` file which seems to solve it for all detectors.