### PR TITLE
Changed python dependencies installation

### DIFF
--- a/dependencies/install.sh
+++ b/dependencies/install.sh
@@ -20,11 +20,11 @@ if [ -f "linux_dependencies.txt" ]; then
        rm linux_dependencies.txt
 fi
 if [ -f "python_prerequisites.txt" ]; then
-       pip install -r python_prerequisites.txt
+       cat python_prerequisites.txt | while read PACKAGE; do pip install $PACKAGE; done
        rm python_prerequisites.txt
 fi
 if [ -f "python_dependencies.txt" ]; then
-       pip install -r python_dependencies.txt
+       cat python_dependencies.txt | while read PACKAGE; do pip install $PACKAGE; done
        rm python_dependencies.txt
 fi
 
@@ -35,10 +35,10 @@ if [ -f "linux_dependencies.txt" ]; then
        rm linux_dependencies.txt
 fi
 if [ -f "python_prerequisites.txt" ]; then
-       pip install -r python_prerequisites.txt
+       cat python_prerequisites.txt | while read PACKAGE; do pip install $PACKAGE; done
        rm python_prerequisites.txt
 fi
 if [ -f "python_dependencies.txt" ]; then
-       pip install -r python_dependencies.txt
+       cat python_dependencies.txt | while read PACKAGE; do pip install $PACKAGE; done
        rm python_dependencies.txt
 fi

--- a/dependencies/parse_dependencies.py
+++ b/dependencies/parse_dependencies.py
@@ -20,6 +20,7 @@
 import os
 import sys
 from configparser import ConfigParser
+from warnings import warn
 
 global flag_efficientNet
 flag_efficientNet = ''
@@ -28,10 +29,12 @@ python_prerequisites_file = "python_prerequisites.txt"
 python_file = "python_dependencies.txt"
 linux_file = "linux_dependencies.txt"
 
+
 def read_ini(path):
     opendr_device = os.environ.get('OPENDR_DEVICE', default='cpu')
     parser = ConfigParser()
     parser.read(path)
+
     def read_ini_key(key, summary_file):
         tool_device = parser.get('device', 'opendr_device', fallback='cpu')
         if opendr_device == 'cpu' and tool_device == 'gpu':
@@ -45,6 +48,7 @@ def read_ini(path):
                         continue
                     with open(summary_file, "a") as f:
                         f.write(os.path.expandvars(package) + '\n')
+
     read_ini_key('python-dependencies', python_prerequisites_file)
     read_ini_key('python', python_file)
     read_ini_key('linux', linux_file)
@@ -58,7 +62,106 @@ def efficientNetTrick(package):
     # only with EfficientLPS version
     elif 'EfficientPS' in package and 'EfficientLPS' not in flag_efficientNet:
         flag_efficientNet = package
-    
+
+
+def verbose_print(message, verbose):
+    if verbose:
+        print(message)
+
+
+def add_dep_to_dict(dep_dict, dep, new_constraint, verbose=False):
+    if dep not in dep_dict.keys():
+        dep_dict[dep] = new_constraint
+        verbose_print(f"no issues adding new dependency: {dep}, {new_constraint}", verbose)
+        return
+    elif dep in dep_dict.keys() and dep_dict[dep] != new_constraint:
+        verbose_print(f"key already exists: {dep} as {dep_dict[dep]}, " +
+                      f"trying to re-add with new_constraint {new_constraint}", verbose)
+
+        # Cases where old/new constraint is loose/strict(==) are clear
+        if new_constraint is None:
+            verbose_print("Original is strict, not re-adding as loose, skipping...", verbose)
+        elif dep_dict[dep] is None:
+            verbose_print("Original is loose, re-adding with more strict, adding...", verbose)
+            dep_dict[dep] = new_constraint
+
+        # Cases where one of the dependencies is strict and the other is half-strict (>, <, >=, <=) are not that clear
+        elif "==" in new_constraint and "==" not in dep_dict[dep]:
+            verbose_print("Original is half-strict, re-adding with strict, adding...", verbose)
+            if dep_dict[dep][0] != new_constraint[0]:
+                warn("[WARNING] Filtering dependencies, probable clash of strict and non-strict versions "
+                     f"of same package. {dep} tries to constraint both to version {dep_dict[dep]} and "
+                     f"{new_constraint}, please review.")
+            dep_dict[dep] = new_constraint
+        elif "==" in dep_dict[dep] and "==" not in new_constraint:
+            verbose_print("Original is strict (==), new isn't, skipping...", verbose)
+            if dep_dict[dep][0] != new_constraint[0]:
+                warn("[WARNING] Filtering dependencies, probable clash of strict and non-strict versions "
+                     f"of same package. {dep} tries to constraint both to version {dep_dict[dep]} and "
+                     f"{new_constraint}, please review.")
+
+        # Critical clash of strict but different constraints
+        elif "==" in dep_dict[dep] and "==" in new_constraint:
+            raise EnvironmentError(f"Filtering dependencies, critical clash of strict versions of same package. "
+                                   f"{dep} tries to constraint both to version {dep_dict[dep]} and {new_constraint}.")
+
+        # Remaining cases with half-strict constraints, not that clear
+        else:
+            warn("[WARNING] Probably case where different half-strict (<=, >=, etc.) constraints clash. "
+                 f"Attempted to add {dep}, {new_constraint}. Kept original dependency {dep}, {dep_dict[dep]}, "
+                 "please review.")
+        return
+    else:
+        verbose_print(f"key already exists: {dep}, as  {dep_dict[dep]}, " +
+                      f"tried to add with same constraint {new_constraint}", verbose)
+        return
+
+
+def filter_dependencies(dependencies, verbose=False):
+    filt_dependencies = {}
+    filtered_dependencies_list = []
+
+    # Filter dependencies by adding them in a dictionary
+    for d in dependencies:
+        if "git" in d:
+            # Git dependency, add as-is
+            add_dep_to_dict(filt_dependencies, d, None, verbose)
+        elif "==" in d:
+            d, dep_ver = d.split("==")[0], d.split("==")[1]
+            add_dep_to_dict(filt_dependencies, d, [dep_ver, "=="], verbose)
+        elif "," in d:
+            # Upper and lower constraint, add as-is
+            add_dep_to_dict(filt_dependencies, d, None, verbose)
+            warn(f"[WARNING] added a dependency {d}, with both an upper and a lower version, please review.")
+        elif "<=" in d:
+            d, dep_ver = d.split("<=")[0], d.split("<=")[1]
+            add_dep_to_dict(filt_dependencies, d, [dep_ver, "<="], verbose)
+        elif ">=" in d:
+            d, dep_ver = d.split(">=")[0], d.split(">=")[1]
+            add_dep_to_dict(filt_dependencies, d, [dep_ver, ">="], verbose)
+        elif ">" in d:
+            d, dep_ver = d.split(">")[0], d.split(">")[1]
+            add_dep_to_dict(filt_dependencies, d, [dep_ver, ">"], verbose)
+        elif "<" in d:
+            d, dep_ver = d.split("<")[0], d.split("<")[1]
+            add_dep_to_dict(filt_dependencies, d, [dep_ver, "<"], verbose)
+        else:
+            # Simple dependency (no constraint), add as-is
+            add_dep_to_dict(filt_dependencies, d, None, verbose)
+        if verbose:
+            print("")
+
+    # Gather dependencies with their constraints in a list
+    for key, val in filt_dependencies.items():
+        full_dep = key
+        if val is not None:
+            full_dep += val[1] + val[0]
+        filtered_dependencies_list.append(full_dep)
+    if filtered_dependencies_list[-1] == "":
+        filtered_dependencies_list = filtered_dependencies_list[0:-1]  # Remove empty last line
+
+    return filtered_dependencies_list
+
 
 # Parse arguments
 section = "runtime"
@@ -96,27 +199,17 @@ with open(python_file, "r") as f:
         # Grab line and remove newline char
         python_dependencies.append(line.replace("\n", ""))
 
-python_dependencies = python_dependencies[0:-1]  # Remove last new line
-# Eliminate duplicates
-python_dependencies_filtered = []
-[python_dependencies_filtered.append(x) for x in python_dependencies if x not in python_dependencies_filtered]
+# Set verbose to True to debug dependencies in detail
+filtered_dependencies = filter_dependencies(python_dependencies, verbose=False)
+print(f"{len(python_dependencies)} dependencies filtered down to {len(filtered_dependencies)}")
 
-python_dependencies_temp = python_dependencies_filtered.copy()
-for pd in python_dependencies_filtered:
-    if "==" in pd:
-        # Found strict dependency
-        pd_ver = pd.split("==")[1]
-        pd = pd.split("==")[0]
-        python_dependencies_temp = [pdt for pdt in python_dependencies_temp if pd not in pdt]
-        python_dependencies_temp.append(pd + "==" + pd_ver)
-
-# # Make igibson last in the installation order
-# python_dependencies_temp.remove("igibson==2.0.3")
-# python_dependencies_temp.append("igibson==2.0.3")
+# # Make igibson last in the installation order, which can fix possible igibson installation error
+# filtered_dependencies.remove("igibson==2.0.3")
+# filtered_dependencies.append("igibson==2.0.3")
 
 with open(python_file, "w") as f:
-    for i in range(len(python_dependencies_filtered)):
-        if i < len(python_dependencies_filtered) - 1:
-            f.write(python_dependencies_filtered[i] + "\n")
+    for i in range(len(filtered_dependencies)):
+        if i < len(filtered_dependencies) - 1:
+            f.write(filtered_dependencies[i] + "\n")
         else:
-            f.write(python_dependencies_filtered[i])
+            f.write(filtered_dependencies[i])

--- a/dependencies/parse_dependencies.py
+++ b/dependencies/parse_dependencies.py
@@ -88,3 +88,35 @@ if not global_dependencies:
                     read_ini(os.path.join(subdir, filename))
 with open(python_file, "a") as f:
     f.write(os.path.expandvars(flag_efficientNet) + '\n')
+
+# Filter python dependencies
+python_dependencies = []
+with open(python_file, "r") as f:
+    for line in f:
+        # Grab line and remove newline char
+        python_dependencies.append(line.replace("\n", ""))
+
+python_dependencies = python_dependencies[0:-1]  # Remove last new line
+# Eliminate duplicates
+python_dependencies_filtered = []
+[python_dependencies_filtered.append(x) for x in python_dependencies if x not in python_dependencies_filtered]
+
+python_dependencies_temp = python_dependencies_filtered.copy()
+for pd in python_dependencies_filtered:
+    if "==" in pd:
+        # Found strict dependency
+        pd_ver = pd.split("==")[1]
+        pd = pd.split("==")[0]
+        python_dependencies_temp = [pdt for pdt in python_dependencies_temp if pd not in pdt]
+        python_dependencies_temp.append(pd + "==" + pd_ver)
+
+# # Make igibson last in the installation order
+# python_dependencies_temp.remove("igibson==2.0.3")
+# python_dependencies_temp.append("igibson==2.0.3")
+
+with open(python_file, "w") as f:
+    for i in range(len(python_dependencies_filtered)):
+        if i < len(python_dependencies_filtered) - 1:
+            f.write(python_dependencies_filtered[i] + "\n")
+        else:
+            f.write(python_dependencies_filtered[i])

--- a/projects/python/perception/activity_recognition/benchmark/install_on_server.sh
+++ b/projects/python/perception/activity_recognition/benchmark/install_on_server.sh
@@ -10,4 +10,4 @@ conda deactivate
 conda activate opendr
 
 pip install torch==1.7.1+cu110 torchvision==0.8.2+cu110 -f https://download.pytorch.org/whl/torch_stable.html
-pip install pytorch_lightning==1.2.3 onnxruntime==1.3.0 joblib>=1.0.1 pytorch_benchmark
+pip install pytorch-lightning==1.2.3 onnxruntime==1.3.0 joblib>=1.0.1 pytorch_benchmark

--- a/projects/python/perception/skeleton_based_action_recognition/benchmark/install_on_server.sh
+++ b/projects/python/perception/skeleton_based_action_recognition/benchmark/install_on_server.sh
@@ -10,4 +10,4 @@ conda deactivate
 conda activate opendr
 
 pip install torch==1.7.1+cu110 torchvision==0.8.2+cu110 -f https://download.pytorch.org/whl/torch_stable.html
-pip install pytorch_lightning==1.2.3 onnxruntime==1.3.0 joblib>=1.0.1 pytorch_benchmark
+pip install pytorch-lightning==1.2.3 onnxruntime==1.3.0 joblib>=1.0.1 pytorch_benchmark

--- a/src/opendr/perception/activity_recognition/dependencies.ini
+++ b/src/opendr/perception/activity_recognition/dependencies.ini
@@ -6,7 +6,7 @@ python=torch==1.13.1
        tqdm
        onnx==1.8.0
        onnxruntime>=1.3.0
-       pytorch_lightning==1.2.3
+       pytorch-lightning==1.2.3
        av==8.0.3
        joblib>=1.0.1
        pyyaml>=5.3

--- a/src/opendr/perception/continual_slam/dependencies.ini
+++ b/src/opendr/perception/continual_slam/dependencies.ini
@@ -4,7 +4,7 @@ python=
         torchvision>=0.10.0
         setuptools>=58.2.0
         numpy
-        Pillow
+        pillow
         tqdm
         matplotlib
         pyyaml

--- a/src/opendr/perception/continual_slam/dependencies.ini
+++ b/src/opendr/perception/continual_slam/dependencies.ini
@@ -1,6 +1,6 @@
 [runtime]
 python=
-        torch>=1.9.0
+        torch==1.13.1
         torchvision>=0.10.0
         setuptools>=58.2.0
         numpy

--- a/src/opendr/perception/facial_expression_recognition/image_based_facial_emotion_estimation/dependencies.ini
+++ b/src/opendr/perception/facial_expression_recognition/image_based_facial_emotion_estimation/dependencies.ini
@@ -12,7 +12,7 @@ python=torch==1.13.1
        matplotlib
        numpy<=1.23.5
        opencv-python
-       Pillow
+       pillow
        pyparsing
        python-dateutil
        six

--- a/src/opendr/perception/gesture_recognition/dependencies.ini
+++ b/src/opendr/perception/gesture_recognition/dependencies.ini
@@ -1,7 +1,7 @@
 [runtime]
 # 'python' key expects a value using the Python requirements file format
 #  https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
-python=torch>=1.9.0
+python=torch==1.13.1
        pytorch-lightning==1.2.3
        protobuf<=3.20.0
        omegaconf>=2.0.1

--- a/src/opendr/perception/skeleton_based_action_recognition/dependencies.ini
+++ b/src/opendr/perception/skeleton_based_action_recognition/dependencies.ini
@@ -11,6 +11,6 @@ python=torch==1.13.1
      onnx==1.8.0
      onnxruntime==1.3.0
      continual-inference>=1.0.2
-     pytorch_lightning==1.2.3
+     pytorch-lightning==1.2.3
 
 opendr=opendr-toolkit-engine


### PR DESCRIPTION
Changed command that parses the created python prerequisites/dependencies files during install.sh so that it installs the pip packages one-by-one. This allows the install script to continue running even after one pip installation fails.

This is not tested thoroughly so i will look into it some more.

~This PR is intended to be merged to master after https://github.com/opendr-eu/opendr/pull/478.~

Update: Case in point, on commit 400b4165c9e66bf45f96f4eb829c3c65b802ed0a , the installation of one package (igibson) failed, but the rest of the installation went smoothly, causing the python env to be created normally for other tools and all the tests to run properly apart from multi-object-search which uses the package that failed.

However, this failure is new and most probably related to this new package installation procedure. More testing is required.

Update: Attempted to filter the temporary python dependencies file by removing duplicates and keeping only strict (==version) versions of packages. Getting this conflict:

`ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
scikit-image 0.21.0 requires imageio>=2.27, but you have imageio 2.6.0 which is incompatible.`

---------

Update: Reworked dependency file filtering from the ground up that can act as a dependency debugging tool. Also slightly cleared up some existing dependencies.

**The new methods warn for possible dependency constraint clashes and throw an error when a definite clash occurs. This happens before the actual pip installations which can help diagnose first-level toolkit dependency clashes early.**