### PR TITLE
Restrict CI to docker tests

### DIFF
--- a/.github/workflows/test_packages.yml
+++ b/.github/workflows/test_packages.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   test-wheel:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test packages') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test packages') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests_suite.yml
+++ b/.github/workflows/tests_suite.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   test-sources:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources')  }}
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +86,7 @@ jobs:
 
   test-tools:
     needs: install-toolkit
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') }}
     strategy:
       fail-fast: false
       matrix:
@@ -271,7 +271,7 @@ jobs:
           dist/*.tar.gz
 
   build-docker:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') }}
     runs-on: ubuntu-20.04
     steps:
     - name: Free Disk Space
@@ -389,7 +389,7 @@ jobs:
 
   test-wheel-separate:
     needs: build-wheel
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') }}
     strategy:
       fail-fast: false
       matrix:
@@ -504,7 +504,7 @@ jobs:
 
   test-docker:
     needs: build-docker
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests_suite_develop.yml
+++ b/.github/workflows/tests_suite_develop.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   test-sources:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test sources') }}
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
         python -m unittest discover -s tests
 
   install-toolkit:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools')  }}
     strategy:
       fail-fast: false
       matrix:
@@ -88,7 +88,7 @@ jobs:
 
   test-tools:
     needs: install-toolkit
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test tools')  }}
     strategy:
       fail-fast: false
       matrix:
@@ -249,7 +249,7 @@ jobs:
         fi
 
   build-wheel:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -275,7 +275,7 @@ jobs:
           dist/*.tar.gz
 
   build-docker:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') }}
     runs-on: ubuntu-20.04
     steps:
     - name: Free Disk Space
@@ -395,7 +395,7 @@ jobs:
 
   test-wheel-separate:
     needs: build-wheel
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') }}
     strategy:
       fail-fast: false
       matrix:
@@ -513,7 +513,7 @@ jobs:
 
   test-docker:
     needs: build-docker
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release') || github.event_name == 'schedule' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test release')  }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In response to #512, this PR restricts CI to prebuilt docker tests untill the issue with github actions is resolved to avoid spending testing resources.