### PR TITLE
fix: Update av dependency to >=12.0.0 for Python 3.12 compatibility

### DIFF
--- a/bin/install_nvidia.sh
+++ b/bin/install_nvidia.sh
@@ -119,7 +119,7 @@ apt-get update && apt-get install -y \
     libavfilter-dev \
     libeigen3-dev
 
-pip3 install av==8.0.1
+pip3 install av>=12.0.0
 
 # Install rest of the dependencies of OpenDR
 

--- a/src/opendr/perception/activity_recognition/dependencies.ini
+++ b/src/opendr/perception/activity_recognition/dependencies.ini
@@ -7,7 +7,7 @@ python=torch==1.13.1
        onnx==1.8.0
        onnxruntime>=1.3.0
        pytorch-lightning==1.2.3
-       av==8.0.3
+       av>=12.0.0
        joblib>=1.0.1
        pyyaml>=5.3
        pandas>=1.2


### PR DESCRIPTION
## Summary
- Update `av` (PyAV) dependency from `==8.0.3` to `>=12.0.0` in `src/opendr/perception/activity_recognition/dependencies.ini`
- Update `av` dependency in `bin/install_nvidia.sh` from `==8.0.1` to `>=12.0.0`

## Problem
Python 3.12 removed `distutils.msvccompiler`, causing opendr-toolkit installation to fail. The `av` package (PyAV) versions prior to 12.0 used `from distutils.msvccompiler import MSVCCompiler`.

## Solution
Update `av` dependency to version 12+, which uses setuptools instead of distutils, restoring Python 3.12 compatibility.

Fixes #515